### PR TITLE
add missing required param for sharing at quickstart docs

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -70,7 +70,8 @@ and give permissions to add content to it:
   curl -X POST -H "Accept: application/json" --user root:root -H "Content-Type: application/json" -d '{
     "prinrole": {
         "Anonymous User": ["guillotina.Member", "guillotina.Reader"]
-    }
+    },
+    "type": "Allow"
   }' "http://127.0.0.1:8080/db/guillotina/@sharing"
 ```
 


### PR DESCRIPTION
Required param `type` was missing for `@sharing` at quickstart doc, I added it with value `Allow` 