### PR TITLE
Documentation: fix endpoint for @addons

### DIFF
--- a/docs/source/training/extending/users.md
+++ b/docs/source/training/extending/users.md
@@ -25,7 +25,7 @@ After you restart guillotina, you can also install `dbusers`
 into your container using the `@addons` endpoint:
 
 ```
-POST /db/container/users
+POST /db/container/@addons
 {
   "id": "dbusers"
 }


### PR DESCRIPTION
To enable `dbusers` we need to post on `addons` endpoint