### PR TITLE
Permission map class inheritance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 2.1.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Properly use super() for security map classes so things can be overridden
+  with custom permission adapters.
+  [vangheem]
 
 
 2.1.18 (2017-12-06)

--- a/guillotina/security/security_local.py
+++ b/guillotina/security/security_local.py
@@ -22,14 +22,13 @@ class GuillotinaRolePermissionManager(GuillotinaSecurityMap):
     key = 'roleperm'
 
     def grant_permission_to_role(self, permission_id, role_id):
-        GuillotinaSecurityMap.add_cell(self, permission_id, role_id, Allow)
+        self.add_cell(permission_id, role_id, Allow)
 
     def grant_permission_to_role_no_inherit(self, permission_id, role_id):
-        GuillotinaSecurityMap.add_cell(
-            self, permission_id, role_id, AllowSingle)
+        self.add_cell(permission_id, role_id, AllowSingle)
 
     def deny_permission_to_role(self, permission_id, role_id):
-        GuillotinaSecurityMap.add_cell(self, permission_id, role_id, Deny)
+        self.add_cell(permission_id, role_id, Deny)
 
     unset_permission_from_role = GuillotinaSecurityMap.del_cell
     get_roles_for_permission = GuillotinaSecurityMap.get_row
@@ -37,8 +36,7 @@ class GuillotinaRolePermissionManager(GuillotinaSecurityMap):
     get_roles_and_permissions = GuillotinaSecurityMap.get_all_cells
 
     def get_setting(self, permission_id, role_id, default=Unset):
-        return GuillotinaSecurityMap.query_cell(
-            self, permission_id, role_id, default)
+        return self.query_cell(permission_id, role_id, default)
 
 
 @configure.adapter(
@@ -53,25 +51,22 @@ class GuillotinaPrincipalPermissionManager(GuillotinaSecurityMap):
     # we'll keep it as is, to prevent breaking old data:
     key = 'prinperm'
 
-    def grant_permission_to_principal(
-            self, permission_id, principal_id):
-        GuillotinaSecurityMap.add_cell(self, permission_id, principal_id, Allow)
+    def grant_permission_to_principal(self, permission_id, principal_id):
+        self.add_cell(permission_id, principal_id, Allow)
 
     def grant_permission_to_principal_no_inherit(
             self, permission_id, principal_id):
-        GuillotinaSecurityMap.add_cell(
-            self, permission_id, principal_id, AllowSingle)
+        self.add_cell(permission_id, principal_id, AllowSingle)
 
     def deny_permission_to_principal(self, permission_id, principal_id):
-        GuillotinaSecurityMap.add_cell(self, permission_id, principal_id, Deny)
+        self.add_cell(permission_id, principal_id, Deny)
 
     unset_permission_for_principal = GuillotinaSecurityMap.del_cell
     get_principals_for_permission = GuillotinaSecurityMap.get_row
     get_permissions_for_principal = GuillotinaSecurityMap.get_col
 
     def get_setting(self, permission_id, principal_id, default=Unset):
-        return GuillotinaSecurityMap.query_cell(
-            self, permission_id, principal_id, default)
+        return self.query_cell(permission_id, principal_id, default)
 
     get_principals_and_permissions = GuillotinaSecurityMap.get_all_cells
 
@@ -85,20 +80,18 @@ class GuillotinaPrincipalRoleManager(GuillotinaSecurityMap):
     key = 'prinrole'
 
     def assign_role_to_principal(self, role_id, principal_id, inherit=True):
-        GuillotinaSecurityMap.add_cell(self, role_id, principal_id, Allow)
+        self.add_cell(role_id, principal_id, Allow)
 
     def assign_role_to_principal_no_inherit(self, role_id, principal_id):
-        GuillotinaSecurityMap.add_cell(
-            self, role_id, principal_id, AllowSingle)
+        self.add_cell(role_id, principal_id, AllowSingle)
 
     def remove_role_from_principal(self, role_id, principal_id):
-        GuillotinaSecurityMap.add_cell(self, role_id, principal_id, Deny)
+        self.add_cell(role_id, principal_id, Deny)
 
     unset_role_for_principal = GuillotinaSecurityMap.del_cell
 
     def get_setting(self, role_id, principal_id, default=Unset):
-        return GuillotinaSecurityMap.query_cell(
-            self, role_id, principal_id, default)
+        return self.query_cell(role_id, principal_id, default)
 
     get_principals_and_roles = GuillotinaSecurityMap.get_all_cells
 

--- a/guillotina/security/securitymap.py
+++ b/guillotina/security/securitymap.py
@@ -129,9 +129,9 @@ class GuillotinaSecurityMap(SecurityMap):
         self.context._p_register()
 
     def add_cell(self, rowentry, colentry, value):
-        if SecurityMap.add_cell(self, rowentry, colentry, value):
+        if super().add_cell(rowentry, colentry, value):
             self._changed()
 
     def del_cell(self, rowentry, colentry):
-        if SecurityMap.del_cell(self, rowentry, colentry):
+        if super().del_cell(rowentry, colentry):
             self._changed()

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -127,7 +127,7 @@ class ContainerRequesterAsyncContextManager(object):
 
     async def __aexit__(self, exc_type, exc, tb):
         resp, status = await self.requester('DELETE', '/db/guillotina')
-        assert status == 200
+        assert status in (200, 404)
 
 
 def create_content(factory=Item, type_name='Item', id=None):


### PR DESCRIPTION
properly use super() so things can be overridden in sub classes for custom adapters.