### PR TITLE
Add debugging for queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+2.3.14 (unreleased)
+-------------------
+
+- Add debugging for queries
+  [vangheem]
+
+
 2.3.13 (2018-01-17)
 -------------------
 

--- a/guillotina/__init__.py
+++ b/guillotina/__init__.py
@@ -7,8 +7,51 @@ from guillotina._cache import PERMISSIONS_CACHE  # noqa
 from guillotina._cache import SCHEMA_CACHE  # noqa
 from guillotina._settings import app_settings  # noqa
 from guillotina.i18n import default_message_factory as _  # noqa
+from guillotina.transactions import get_transaction
 from zope.interface import Interface  # noqa
+
+import os
 
 
 # create logging
 logger = glogging.getLogger('guillotina')
+
+
+if os.environ.get('GDEBUG', '').lower() in ('true', 't', '1'):
+    # patches for extra debugging....
+    import asyncpg
+    import time
+    original_execute = asyncpg.connection.Connection._do_execute
+
+    def _record(query, duration):
+        # log each query on the transaction object...
+        try:
+            txn = get_transaction()
+            if txn:
+                if not hasattr(txn, '_queries'):
+                    txn._queries = {}
+                if query not in txn._queries:
+                    txn._queries[query] = [0, 0.0]
+                txn._queries[query][0] += 1
+                txn._queries[query][1] += duration
+        except AttributeError:
+            pass
+
+    async def _do_execute(self, query, *args, **kwargs):
+        start = time.time()
+        result = await original_execute(self, query, *args, **kwargs)
+        end = time.time()
+        _record(query, end - start)
+        return result
+
+    asyncpg.connection.Connection._do_execute = _do_execute
+
+    original_bind_execute = asyncpg.prepared_stmt.PreparedStatement._PreparedStatement__bind_execute
+
+    async def __bind_execute(self, *args, **kwargs):
+        start = time.time()
+        result = await original_bind_execute(self, *args, **kwargs)
+        end = time.time()
+        _record(self._query, end - start)
+        return result
+    asyncpg.prepared_stmt.PreparedStatement._PreparedStatement__bind_execute = __bind_execute

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -118,6 +118,8 @@ class Transaction(object):
         self._cache = get_adapter(self, IStorageCache,
                                   name=manager._storage._cache_strategy)
 
+        self._query_count_start = self._query_count_end = 0
+
     @property
     def strategy(self):
         return self._strategy

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -187,6 +187,12 @@ class BaseMatchInfo(AbstractMatchInfo):
                     resp.headers['XG-Total-Cache-hits'] = str(txn._manager._storage._hits)
                     resp.headers['XG-Total-Cache-misses'] = str(txn._manager._storage._misses)
                     resp.headers['XG-Total-Cache-stored'] = str(txn._manager._storage._stored)
+                    resp.headers['XG-Num-Queries'] = str(
+                        txn._query_count_end - txn._query_count_start)
+                    for idx, query in enumerate(txn._queries.keys()):
+                        counts = txn._queries[query]
+                        duration = "{0:.5f}".format(counts[1] * 1000)
+                        resp.headers[f'XG-Query-{idx}'] = f'count: {counts[0]}, time: {duration}, query: {query}'  # noqa
                 except AttributeError:
                     pass
             except (KeyError, AttributeError):


### PR DESCRIPTION
Will provide headers like:

```
XG-Num-Queries →2
XG-Query-0 →count: 1, time: 497.04599, query: SELECT zoid, tid, state_size, resource, type, state, id FROM objects WHERE parent_id = $1::varchar(32) AND id = $2::text
XG-Query-1 →count: 1, time: 395.79868, query: SELECT zoid, tid, state_size, resource, type, state, id FROM objects WHERE of = $1::varchar(32) AND id = $2::text AND (parent_id IS NULL OR parent_id != 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD')
```

when run with `XDEBUG:true`