### PR TITLE
Move TRASHED annotation objects check to application logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 3.3.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Move TRASHED annotation objects check to application logic instead
+  of the query. This helps performance and query planer issue for cockroach
+  [vangheem]
 
 
 3.3.10 (2018-05-29)

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -41,7 +41,7 @@ GET_CHILDREN_KEYS = f"""
 GET_ANNOTATIONS_KEYS = f"""
     SELECT id, parent_id
     FROM objects
-    WHERE of = $1::varchar({MAX_OID_LENGTH})'
+    WHERE of = $1::varchar({MAX_OID_LENGTH})
     """
 
 GET_CHILD = f"""


### PR DESCRIPTION
instead of the query. This helps performance and query planer issue for cockroach