### PR TITLE
Allow patching registry with new Interface fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow patching registry with new shcema fields
 
 
 4.0.2 (2018-06-22)

--- a/guillotina/api/registry.py
+++ b/guillotina/api/registry.py
@@ -195,13 +195,14 @@ class Write(Service):
         assert '.' in self.key, 'Registry key must be dotted.iface.name.fieldname'  # noqa
         iface, name = self.key.rsplit('.', 1)
         iface = resolve_dotted_name(iface)
+
         assert iface is not None, 'Must provide valid registry interface'  # noqa
         try:
             field = iface[name]
         except KeyError:
             return ErrorResponse(
                 'DeserializationError',
-                'Invalid field name {}'.format(str(self.field)),
+                'Invalid field name {}'.format(str(name)),
                 status=412)
 
         try:

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -14,6 +14,13 @@ class ITestingRegistry(Interface):  # pylint: disable=E0239
         title="Example attribute")
 
 
+class ITestingRegistryUpdated(Interface):  # pylint: disable=E0239
+    enabled = schema.Bool(
+        title="Example attribute")
+    test = schema.Bool(
+        title="Example attribute")
+
+
 @configure.addon(
     name="testaddon",
     title="Test addon")
@@ -164,6 +171,24 @@ async def test_register_registry(container_requester):
             'GET',
             '/db/guillotina/@registry/guillotina.tests.test_api.ITestingRegistry.enabled')
         assert {'value': False} == response
+
+        # this emulates a registry update
+        from guillotina.tests import test_api
+        test_api.ITestingRegistry = ITestingRegistryUpdated
+
+        response, status = await requester(
+            'PATCH',
+            '/db/guillotina/@registry/guillotina.tests.test_api.ITestingRegistry.test',
+            data=json.dumps({
+                "value": True
+            })
+        )
+        assert status == 204
+        response, status = await requester(
+            'GET',
+            '/db/guillotina/@registry/guillotina.tests.test_api.ITestingRegistry.test')
+        assert {'value': True} == response
+
 
 
 async def test_create_contenttype_with_date(container_requester):


### PR DESCRIPTION
When evolving an interface on the registry, allow to patch with new
fields on the interface