### PR TITLE
Allow DELETE with url instead of payload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 4.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow DELETE with params on url.
+  [jordic]
 
 
 4.0.7 (2018-07-21)

--- a/guillotina/api/behaviors.py
+++ b/guillotina/api/behaviors.py
@@ -55,6 +55,30 @@ async def default_patch(context, request):
 
 @configure.service(
     context=IResource, method='DELETE',
+    permission='guillotina.ModifyContent', name='@behaviors/{behavior}',
+    summary="Remove behavior from resource",
+    parameters=[{
+        "name": "behavior",
+        "in": "path",
+        "schema": {
+            "$ref": "#/definitions/Behavior"
+        }
+    }],
+    responses={
+        "200": {
+            "description": "Successfully removed behavior"
+        },
+        "412": {
+            "description": "Behavior not assigned here"
+        },
+    })
+async def default_delete_withparams(context, request):
+    behavior = request.matchdict['behavior']
+    return await delete_behavior(context, behavior)
+
+
+@configure.service(
+    context=IResource, method='DELETE',
     permission='guillotina.ModifyContent', name='@behaviors',
     summary="Remove behavior from resource",
     parameters=[{
@@ -75,6 +99,10 @@ async def default_patch(context, request):
 async def default_delete(context, request):
     data = await request.json()
     behavior = data.get('behavior', None)
+    return await delete_behavior(context, behavior)
+
+
+async def delete_behavior(context, behavior):
     factory = get_cached_factory(context.type_name)
     behavior_class = resolve_dotted_name(behavior)
     if behavior_class is not None:

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -349,6 +349,25 @@ async def test_uninstall_addons(container_requester):
         assert response is None
 
 
+async def test_uninstall_addons_path(container_requester):
+    id_ = 'testaddon'
+    async with container_requester as requester:
+        await requester(
+            'POST',
+            '/db/guillotina/@addons',
+            data=json.dumps({
+                "id": id_
+            })
+        )
+
+        response, status = await requester(
+            'DELETE',
+            f'/db/guillotina/@addons/{id_}',
+        )
+        assert status == 200
+        assert response is None
+
+
 async def test_uninstall_invalid_addon(container_requester):
     async with container_requester as requester:
         _, status = await requester(

--- a/guillotina/tests/test_dynamic_schema.py
+++ b/guillotina/tests/test_dynamic_schema.py
@@ -244,6 +244,37 @@ async def test_create_delete_dynamic_behavior(custom_type_container_requester):
         assert 'guillotina.test_package.ITestBehavior' not in response
 
 
+async def test_delete_dynamic_behavior_url(custom_type_container_requester):
+    async with custom_type_container_requester as requester:
+        response, status = await requester(
+            'POST',
+            '/db/guillotina/',
+            data=json.dumps({
+                "@type": "Foobar",
+                "title": "Item1",
+                "id": "item1"
+            })
+        )
+        assert status == 201
+
+        # We create the behavior
+        response, status = await requester(
+            'PATCH',
+            '/db/guillotina/item1/@behaviors',
+            data=json.dumps({
+                'behavior': 'guillotina.test_package.ITestBehavior'
+            })
+        )
+        assert status == 200
+
+        # We delete the behavior
+        response, status = await requester(
+            'DELETE',
+            '/db/guillotina/item1/@behaviors/guillotina.test_package.ITestBehavior'
+        )
+        assert status == 200
+
+
 async def test_get_behaviors(custom_type_container_requester):
     async with custom_type_container_requester as requester:
         response, status = await requester(


### PR DESCRIPTION
Allow deleting items without a payload i
Instead of providing a body payload to the DELETE method,
allow uninstall them, with a request on path:

DEL @addon/addonid
DEL @behavior/behaviour.id.id