### PR TITLE
Behaviors by default correctly mark object with schema if no marker provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 4.1.12 (unreleased)
 -------------------
 
+- Behaviors by default correctly mark object with schema if no marker provided
+  [vangheem]
+
 - Move static guillotina assets into python package so they can be
   referenced from python dotted paths with `guillotina:static/assets`
   [vangheem]

--- a/guillotina/configure/__init__.py
+++ b/guillotina/configure/__init__.py
@@ -209,7 +209,7 @@ def load_behavior(_context, behavior):
     for_ = resolve_dotted_name(conf.get('for_'))
     marker = resolve_dotted_name(conf.get('marker'))
 
-    if marker is None and real_factory is None:
+    if marker is None:
         marker = schema
 
     if marker is not None and real_factory is None and marker is not schema:


### PR DESCRIPTION
with `if marker is None and real_factory is None:`, `real_factory` was never `None`