### PR TITLE
Improved index page of the docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@
 
   [ebrehault]
 
+- Improve Documentation
+
+  [hirokiky]
+
 
 4.2.12 (2018-11-07)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 4.2.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve Documentation
+
+  [hirokiky]
 
 
 4.2.13 (2018-11-09)
@@ -14,10 +16,6 @@
   - Add medium-like richtext editor
 
   [ebrehault]
-
-- Improve Documentation
-
-  [hirokiky]
 
 
 4.2.12 (2018-11-07)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -138,7 +138,7 @@ The endpoints available around these objects are detailed below:
 
 # About
 
-- [Read about](./installation/about.html) the rich history of the project
+- [Read about](./about.html) the rich history of the project
 
 ```eval_rst
  .. toctree::

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -54,6 +54,9 @@ The endpoints available around these objects are detailed below:
 
 # Narrative Developer Documentation
 
+After reading quick tour or training section,
+Now you can start hands-on style guide to learn how to use it.
+
 ```eval_rst
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,6 +3,27 @@
 Guillotina is the only full-featured Python AsyncIO REST Resource Application
 Server designed for high-performance, horizontally scaling solutions.
 
+## Why Guillotina
+
+ - **Performance**: Traditional Python web servers limit the number of simultaneous
+   requests to the number of threads running the server. With AsyncIO, you are
+   able to serve many more simultaneous requests.
+ - **Front-end friendly**: Guillotina is designed to make your
+   JavaScript engineers happy. With things like automatic Swagger documentation
+   for endpoints, out of the box CORS and websockets, your front-end team will be happy
+   to work with Guillotina. We speak JSON but can adapt to any content type
+   payload request/response bodies.
+ - **AsyncIO**: With AsyncIO, websockets are simple. More interestingly, AsyncIO
+   is an ideal match with microservice architectures.
+ - **Object model**: Guillotina uses a hierarchial object model. This hierarchy
+   of objects then maps to URLs and is perfect for managing
+   a large number of objects.
+ - **Security**: Guillotina has a granular, hierarchical, multidimensional
+   security system that allows you to manage the security of your content
+   at a level not available to other frameworks.
+ - **Scale**: With integrations like Redis, ElasticSearch and Cockroach, you
+   have the tools to scale.
+
 # Getting Started
 
 Are you new to Guillotina? This is the place to start!
@@ -115,27 +136,6 @@ Now you can start hands-on style guide to learn how to use it.
    api/utils
    api/component
 ```
-
-# Why Guillotina
-
- - **Performance**: Traditional Python web servers limit the number of simultaneous
-   requests to the number of threads running the server. With AsyncIO, you are
-   able to serve many more simultaneous requests.
- - **Front-end friendly**: Guillotina is designed to make your
-   JavaScript engineers happy. With things like automatic Swagger documentation
-   for endpoints, out of the box CORS and websockets, your front-end team will be happy
-   to work with Guillotina. We speak JSON but can adapt to any content type
-   payload request/response bodies.
- - **AsyncIO**: With AsyncIO, websockets are simple. More interestingly, AsyncIO
-   is an ideal match with microservice architectures.
- - **Object model**: Guillotina uses a hierarchial object model. This hierarchy
-   of objects then maps to URLs and is perfect for managing
-   a large number of objects.
- - **Security**: Guillotina has a granular, hierarchical, multidimensional
-   security system that allows you to manage the security of your content
-   at a level not available to other frameworks.
- - **Scale**: With integrations like Redis, ElasticSearch and Cockroach, you
-   have the tools to scale.
 
 # About
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,13 +7,22 @@ Server designed for high-performance, horizontally scaling solutions.
 
 Are you new to Guillotina? This is the place to start!
 
- - [Quick tour of Guillotina](./quick-tour.html) gives an overview of the major features in
-   Guillotina, covering a little about a lot.
- - To learn more, go to the [training section](./training/index.html).
- - For help getting Guillotina set up, try
-   [Installing Guillotina](./installation/installation.html).
- - Need help? Join our [Gitter channel](https://gitter.im/plone/guillotina).
+[Quick tour of Guillotina](./quick-tour.html) gives an overview of the major features in
+Guillotina, covering a little about a lot.
 
+Need help? Join our [Gitter channel](https://gitter.im/plone/guillotina).
+
+# Training / Tutorial
+
+To learn more, go to the [training section](./training/index.html).
+You can learn basics and find topics about Guillotina:
+
+```eval_rst
+.. toctree::
+   :maxdepth: 2
+
+   training/index
+```
 
 # REST API
 
@@ -102,17 +111,6 @@ The endpoints available around these objects are detailed below:
    api/fields
    api/utils
    api/component
-```
-
-
-# Training
-
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   training/*
 ```
 
 # Why Guillotina


### PR DESCRIPTION
I started guillotina in these days, and I thought the index page of the docs can be improved to find information.

* Fixed broken link
* We need to read the "training" before the "Narrative guide", but the link for "training" is too small

I fixed order of each information, like from shallow to deeper one.
