### PR TITLE
Sample request on doc using "Role" params will cause error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 - Improve Documentation
 
+  - Index page
+  - Security page
+
   [hirokiky]
 
 

--- a/docs/source/developer/security.md
+++ b/docs/source/developer/security.md
@@ -393,7 +393,7 @@ id):
         "prinrole": [
             {
                 "principal": "Alice",
-                "Role": "guillotina.Editor",
+                "role": "guillotina.Editor",
                 "setting": "Allow"
             }
         ]
@@ -427,7 +427,7 @@ Let's fix that by giving "guillotina.DeleteContent" permission to
         "roleperm": [
             {
                 "permission": "guillotina.DeleteContent",
-                "Role": "guillotina.Editor",
+                "role": "guillotina.Editor",
                 "setting": "Allow"
             }
         ]


### PR DESCRIPTION
Sample requests to apply role will cause error

```python
{
    "prinrole": [
        {
            "principal": "Alice",
            "Role": "guillotina.Editor",
            "setting": "Allow"
        }
    ]
}
```

It looks the `"Role"` property should be `"role"`.
And these requests will cause bellow error:

```
RUNNING IN DEBUG MODE
======== Running on http://localhost:8080 ========
(Press CTRL+C to quit)
Error on execution of view cb7dabf5b53f4a54aac65fa761f25813
Traceback (most recent call last):
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/traversal.py", line 258, in handler
    view_result = await self.view()
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/api/content.py", line 401, in __call__
    return await apply_sharing(context, data)
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/security/utils.py", line 175, in apply_sharing
    if prinrole['role'] in lroles:
KeyError: 'role'
Error on execution of view 16759ae1d2f84017ba3ca40b38a67252
Traceback (most recent call last):
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/traversal.py", line 258, in handler
    view_result = await self.view()
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/api/content.py", line 401, in __call__
    return await apply_sharing(context, data)
  File "/home/hirokiky/dev/demotina/venv/lib/python3.7/site-packages/guillotina/security/utils.py", line 175, in apply_sharing
    if prinrole['role'] in lroles:
KeyError: 'role'
```

https://github.com/plone/guillotina/blob/master/guillotina/security/utils.py#L175

## My environment

* guillotina (4.2.13)
* Python (3.7.0)

If you need more information, please ask me I will share.