### PR TITLE
modify for deprecated on docs from `logger.warn` to `logger.warning`

### DIFF
--- a/docs/source/training/extending/utilities.md
+++ b/docs/source/training/extending/utilities.md
@@ -60,7 +60,7 @@ class MessageSenderUtility:
                             await ws.send_str(json.dumps(
                                 summary, cls=GuillotinaJSONEncoder))
             except Exception:
-                logger.warn(
+                logger.warning(
                     'Error sending message',
                     exc_info=True)
                 await asyncio.sleep(1)


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logging.Logger.warning