### PR TITLE
Fix Resource.__getattr__() for empty fields with default values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 4.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Resource.__getattr__() for empty fields with default values
+  [masipcat]
 
 
 4.3.5 (2018-12-09)

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -261,6 +261,7 @@ class Resource(guillotina.db.orm.base.BaseObject):
             name
         )
         if value is not _marker:
+            setattr(self, name, value)
             return value
         raise AttributeError(name)
 

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -165,6 +165,8 @@ async def test_getattr_set_default(container_requester):
     images1 = custom_content.images
     images2 = custom_content.images
 
+    assert isinstance(images1, dict)
+
     # Assert that obj.__getattr__() returns always same instance of default value
     # for empty fields
     assert id(images1) == id(images2)

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -25,7 +25,7 @@ class ICustomContentType(IItem):
         key_type=TextLine(),
         value_type=TextLine(),
         required=False,
-        default={}
+        defaultFactory=dict
     )
 
 
@@ -165,6 +165,6 @@ async def test_getattr_set_default(container_requester):
     images1 = custom_content.images
     images2 = custom_content.images
 
-    # Assert that obj.__getattr__() returns same instance for empty fields with
-    # default value
+    # Assert that obj.__getattr__() returns always same instance of default value
+    # for empty fields
     assert id(images1) == id(images2)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={'': ['*.txt', '*.rst', 'guillotina/documentation/meta/*.json']},
     packages=find_packages(),
     install_requires=[
-        'aiohttp>=3.0.0,<4.0.0',
+        'aiohttp==3.4.4',
         'jsonschema',
         'python-dateutil',
         'pycryptodome',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={'': ['*.txt', '*.rst', 'guillotina/documentation/meta/*.json']},
     packages=find_packages(),
     install_requires=[
-        'aiohttp==3.4.4',
+        'aiohttp>=3.0.0,<3.5.0',
         'jsonschema',
         'python-dateutil',
         'pycryptodome',


### PR DESCRIPTION
Fixes https://github.com/plone/guillotina/issues/393