### PR TITLE
pay attention to forwarded headers in urls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,20 @@
 4.4.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- provide `guillotina.utils.get_url` function that pays attention
+  to `X-VirtualHost-Monster` header
+  [vangheem]
+
+- Take `X-Forwarded-Proto` into account for request url
+  [vangheem]
+
+- Implement multi attachments
+  [masipcat]
 
 
 4.4.5 (2019-01-11)
 ------------------
 
-- Implement multi attachments
-  [masipcat]
 - Allow to login on IApplication.
   [bloodbare]
 

--- a/guillotina/browser.py
+++ b/guillotina/browser.py
@@ -6,6 +6,7 @@ from guillotina.interfaces import IRequest
 from guillotina.interfaces import IResource
 from guillotina.interfaces import IView
 from guillotina.utils import get_current_request
+from guillotina.utils import get_url
 from zope.interface import implementer
 
 
@@ -65,24 +66,12 @@ class Absolute_URL(object):
         else:
             path = '/'.join(get_physical_path(self.context))
 
-        if 'X-VirtualHost-Monster' in self.request.headers:
-            virtualhost = self.request.headers['X-VirtualHost-Monster']
-        else:
-            virtualhost = None
-
         if container_url:
             return path
         elif relative:
             return '/' + self.request._db_id + path
-        elif virtualhost:
-            return virtualhost + self.request._db_id + path
         else:
-            if 'X-Forwarded-Proto' in self.request.headers:
-                scheme = self.request.headers['X-Forwarded-Proto']
-            else:
-                scheme = self.request.scheme
-            return scheme + '://' + (self.request.host or 'localhost') + '/' +\
-                self.request._db_id + path
+            return get_url(self.request, self.request._db_id + path)
 
 
 @configure.adapter(

--- a/guillotina/tests/test_urls.py
+++ b/guillotina/tests/test_urls.py
@@ -1,0 +1,55 @@
+from guillotina.tests.utils import make_mocked_request
+from guillotina.utils import get_url
+import json
+
+
+def test_vhm_url(dummy_guillotina):
+    request = make_mocked_request('GET', '/', {
+        'X-VirtualHost-Monster': 'https://foobar.com/foo/bar'
+    })
+
+    assert get_url(
+        request, '/c/d') == 'https://foobar.com/foo/bar/c/d'
+
+
+def test_forwarded_proto_url(dummy_guillotina):
+    request = make_mocked_request('GET', '/', {
+        'X-Forwarded-Proto': 'https'
+    })
+    url = get_url(request, '/c/d')
+    assert url.startswith('https://')
+    assert url.endswith('/c/d')
+
+
+async def test_url_of_object_with_vhm(container_requester):
+    async with container_requester as requester:
+        resp, _ = await requester(
+            'POST',
+            '/db/guillotina/',
+            data=json.dumps({
+                '@type': 'Item'
+            }),
+            headers={
+                'X-VirtualHost-Monster': 'https://foobar.com/foo/bar'
+            }
+        )
+        assert resp['@id'].startswith(
+            'https://foobar.com/foo/bar/db/guillotina')
+
+
+async def test_url_of_object_with_scheme(container_requester):
+    async with container_requester as requester:
+        resp, _ = await requester(
+            'POST',
+            '/db/guillotina/',
+            data=json.dumps({
+                '@type': 'Item',
+                'id': 'foobar'
+            }),
+            headers={
+                'X-VirtualHost-Monster': 'https://foobar.com/foo/bar'
+            }
+        )
+        url = resp['@id']
+        assert url.startswith('https://')
+        assert url.endswith('/db/guillotina/foobar')

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -353,21 +353,12 @@ class TraversalRouter(AbstractRouter):
         """Warpper to set the root object."""
         self._root = root
 
-    def munge_request(self, req):
-        for hdr in ('X-Forwarded-Proto', 'X-Forwarded-Scheme',):
-            forwarded_proto = req.headers.get(hdr, None)
-            if forwarded_proto:
-                req = req.clone(scheme=forwarded_proto)
-                break
-        return req
-
     async def resolve(self, request: IRequest) -> BaseMatchInfo:
         '''
         Resolve a request
         '''
         # prevent: https://github.com/aio-libs/aiohttp/issues/3335
         request.url
-        request = self.munge_request(request)
 
         request.record('start')
         result = None

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -353,12 +353,21 @@ class TraversalRouter(AbstractRouter):
         """Warpper to set the root object."""
         self._root = root
 
+    def munge_request(self, req):
+        for hdr in ('X-Forwarded-Proto', 'X-Forwarded-Scheme',):
+            forwarded_proto = req.headers.get(hdr, None)
+            if forwarded_proto:
+                req = req.clone(scheme=forwarded_proto)
+                break
+        return req
+
     async def resolve(self, request: IRequest) -> BaseMatchInfo:
         '''
         Resolve a request
         '''
         # prevent: https://github.com/aio-libs/aiohttp/issues/3335
         request.url
+        request = self.munge_request(request)
 
         request.record('start')
         result = None

--- a/guillotina/utils/__init__.py
+++ b/guillotina/utils/__init__.py
@@ -14,6 +14,7 @@ from .misc import apply_coroutine  # noqa
 from .misc import clear_conn_statement_cache  # noqa
 from .misc import get_current_request  # noqa
 from .misc import get_random_string  # noqa
+from .misc import get_url  # noqa
 from .misc import lazy_apply  # noqa
 from .misc import list_or_dict_items  # noqa
 from .misc import loop_apply_coroutine  # noqa

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -262,3 +262,25 @@ def safe_unidecode(val: bytes) -> str:
         except UnicodeDecodeError:
             pass
     return val.decode('utf-8', errors='replace')
+
+
+def get_url(req, path):
+    '''
+    Return calculated url from a request object taking
+    into account X-VirtualHost-Monster header
+    '''
+    if 'X-VirtualHost-Monster' in req.headers:
+        virtualhost = req.headers['X-VirtualHost-Monster']
+    else:
+        virtualhost = None
+
+    if virtualhost:
+        return '{}/{}'.format(virtualhost.rstrip('/'), path.strip('/'))
+    else:
+        url = req.url.with_path(path)
+        for hdr in ('X-Forwarded-Proto', 'X-Forwarded-Scheme',):
+            forwarded_proto = req.headers.get(hdr, None)
+            if forwarded_proto:
+                url = url.with_scheme(forwarded_proto)
+                break
+        return str(url)


### PR DESCRIPTION
For add-ons that need to generate correct urls, they should now use 'utils.get_url` instead of `request.url.with_path`