### PR TITLE
Improved _check_bad_connection()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 4.4.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improved PostgresqlStorage._check_bad_connection()
+  [masipcat]
 
 
 4.4.10 (2019-01-23)

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -239,10 +239,8 @@ def restart_conn_on_exception(f):
     async def decorator(self: 'PostgresqlStorage', *args, **kwargs):
         try:
             return await f(self, *args, **kwargs)
-        except asyncpg.exceptions.PostgresConnectionError as ex:
-            await self._check_bad_connection(ex)
-            raise
-        except asyncpg.exceptions.InterfaceError as ex:
+        except (asyncpg.exceptions.PostgresConnectionError,
+                asyncpg.exceptions.InterfaceError) as ex:
             await self._check_bad_connection(ex)
             raise
 


### PR DESCRIPTION
Closes https://github.com/plone/guillotina/issues/410

There are more places where we should add this `except asyncpg.exceptions.PostgresConnectionError`. Maybe we could use a decorator like `@restart_conn_on_exception` that calls `_check_bad_connections()` for all the except cases.