### PR TITLE
Add 'db_schema' to postgresql storage config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 4.5.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add 'db_schema' to postgresql storage config
+  [masipcat]
 
 
 4.5.5 (2019-02-15)

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -13,6 +13,7 @@ from guillotina.db.interfaces import IPostgresStorage
 from guillotina.db.oid import MAX_OID_LENGTH
 from guillotina.db.storages.base import BaseStorage
 from guillotina.db.storages.utils import SQLStatements
+from guillotina.db.storages.utils import get_index_name
 from guillotina.db.storages.utils import get_table_definition
 from guillotina.db.storages.utils import register_sql
 from guillotina.exceptions import ConflictError
@@ -495,7 +496,7 @@ class PostgresqlStorage(BaseStorage):
 
     def __init__(self, dsn=None, partition=None, read_only=False, name=None,
                  pool_size=13, transaction_strategy='resolve_readcommitted',
-                 conn_acquire_timeout=20, cache_strategy='dummy',
+                 conn_acquire_timeout=20, cache_strategy='dummy', db_schema='public',
                  objects_table_name='objects', blobs_table_name='blobs',
                  connection_manager=None, **options):
         super(PostgresqlStorage, self).__init__(
@@ -510,8 +511,9 @@ class PostgresqlStorage(BaseStorage):
         self._options = options
         self._connection_options = {}
         self._connection_initialized_on = time.time()
-        self._objects_table_name = objects_table_name
-        self._blobs_table_name = blobs_table_name
+        self._db_schema = db_schema
+        self._objects_table_name = f'{db_schema}.{objects_table_name}'
+        self._blobs_table_name = f'{db_schema}.{blobs_table_name}'
         self._sql = SQLStatements()
         self._connection_manager = connection_manager
 
@@ -539,18 +541,24 @@ class PostgresqlStorage(BaseStorage):
     async def create(self):
         # Check DB
         log.info('Creating initial database objects')
-        statements = [
+
+        statements = []
+
+        if self._db_schema:
+            statements.extend([f'CREATE SCHEMA IF NOT EXISTS {self._db_schema}'])
+
+        statements.extend([
             get_table_definition(self._objects_table_name, self._object_schema),
             get_table_definition(self._blobs_table_name, self._blob_schema,
                                  primary_keys=('bid', 'zoid', 'chunk_index'))
-        ]
+        ])
         statements.extend(self._initialize_statements)
 
         for statement in statements:
-            otable_name = self._objects_table_name
+            otable_name = get_index_name(self._objects_table_name)
             if otable_name == 'objects':
                 otable_name = 'object'
-            btable_name = self._blobs_table_name
+            btable_name = get_index_name(self._blobs_table_name)
             if btable_name == 'blobs':
                 btable_name = 'blob'
             statement = statement.format(
@@ -585,7 +593,7 @@ FROM
     JOIN information_schema.constraint_column_usage AS ccu
     ON ccu.constraint_name = tc.constraint_name
 WHERE tc.constraint_name = '{}_parent_id_id_key' AND tc.constraint_type = 'UNIQUE'
-'''.format(self._objects_table_name))
+'''.format(get_index_name(self._objects_table_name)))
         return len(result) > 0
 
     async def initialize(self, loop=None, **kw):

--- a/guillotina/db/storages/utils.py
+++ b/guillotina/db/storages/utils.py
@@ -1,9 +1,16 @@
+def get_index_name(table_name):
+    if '.' in table_name:
+        _, table_name = table_name.split(".", 1)  # i.e.: 'public.objects' -> 'objects'
+    return table_name
 
 
 def get_table_definition(name, schema, primary_keys=[]):
     pk = ''
     if len(primary_keys) > 0:
-        pk = ', CONSTRAINT pk_{} PRIMARY KEY({})'.format(name, ', '.join(primary_keys))
+        pk = ', CONSTRAINT pk_{} PRIMARY KEY({})'.format(
+            get_index_name(name),
+            ', '.join(primary_keys)
+        )
     return "CREATE TABLE IF NOT EXISTS {} ({}{});".format(
         name,
         ',\n'.join('{} {}'.format(c, d) for c, d in schema.items()),


### PR DESCRIPTION
Closes https://github.com/plone/guillotina/issues/424

This is the easiest approach I found but there are some alternative to this implementation:

1. Instead of storing `schema.table_name` in attribute `_objects_table_name` we can change all the sql statatements to accept the 'schema' as a parameter.
2. Execute `SET SCHEMA {schema}` when opening a connection
3. Ideas?