### PR TITLE
Fix `GuillotinaDBRequester.make_request()` not decoding json responses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 4.5.7 (unreleased)
 ------------------
 
+- Fix `GuillotinaDBRequester.make_request()` not decoding json responses
+  [masipcat]
 - Missing 'db_schema' in 'tid_sequence' table
   [masipcat]
 - Add 'db_schema' to postgresql storage config

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import aiohttp
 import pytest
+from aiohttp.client_exceptions import ContentTypeError
 from aiohttp.test_utils import TestServer
 from guillotina import testing
 from guillotina.component import get_utility
@@ -173,12 +174,12 @@ class GuillotinaDBRequester(object):
         async with aiohttp.ClientSession(loop=self.loop) as session:
             operation = getattr(session, method.lower(), None)
             async with operation(self.server.make_url(path), **settings) as resp:
-                if resp.headers.get('Content-Type') == 'application/json':
+                try:
                     value = await resp.json()
-                    status = resp.status
-                else:
+                except ContentTypeError:
                     value = await resp.read()
-                    status = resp.status
+
+                status = resp.status
                 return value, status, resp.headers
 
     def transaction(self, request=None):


### PR DESCRIPTION
When a `Service` uses `json_response()` to response with JSON data, the content type is `Content-Type: application/json; charset=utf-8` and the previous implementation doesn't work. I think its better to designate the responsibility to detect JSON responses to aiohttp.

Thank you!