### PR TITLE
Request indexer override

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Provide `connection_settings` on the request object with `tests.utils.get_container`
+  [vangheem]
 
 
 4.7.1 (2019-04-26)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.7.2 (unreleased)
 ------------------
 
-- Provide `connection_settings` on the request object with `tests.utils.get_container`
+- Provide `request_indexer` setting to be able to override how we handle
+  indexing data
   [vangheem]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ CHANGELOG
   indexing data
   [vangheem]
 
+- Provide `connection_settings` on the request object with `tests.utils.get_container`
+  [vangheem]
+
 
 4.7.1 (2019-04-26)
 ------------------

--- a/guillotina/_settings.py
+++ b/guillotina/_settings.py
@@ -89,6 +89,7 @@ app_settings: Dict[str, Any] = {
     "pg_connection_class": "asyncpg.connection.Connection",
     "oid_generator": generate_oid,
     "cors_renderer": "guillotina.cors.DefaultCorsRenderer",
-    "check_writable_request": "guillotina.writable.check_writable_request"
+    "check_writable_request": "guillotina.writable.check_writable_request",
+    "request_indexer": "guillotina.catalog.index.RequestIndexer"
 }
 default_settings = copy.deepcopy(app_settings)

--- a/guillotina/catalog/index.py
+++ b/guillotina/catalog/index.py
@@ -65,6 +65,7 @@ class RequestIndexer:
 
     async def add_object(self, obj, indexes=None, modified=False, security=False):
         uid = obj.uuid
+        search = query_utility(ICatalogUtility)
         if modified:
             data = {}
             if security:
@@ -73,9 +74,6 @@ class RequestIndexer:
                     data = await apply_coroutine(adapter)
             else:
                 if indexes is not None and len(indexes) > 0:
-                    search = query_utility(ICatalogUtility)
-                    if search is None:
-                        return
                     data = await search.get_data(obj, indexes)
             if len(data) > 0:
                 if uid in self.update:

--- a/guillotina/catalog/index.py
+++ b/guillotina/catalog/index.py
@@ -55,7 +55,7 @@ class RequestIndexer:
     def reindex_security(self, obj):
         reindex_in_future(obj, self.request, True)
 
-    def remove(self, obj):
+    def remove_object(self, obj):
         self.remove.append(obj)
         uid = obj.uuid
         if uid in self.index:
@@ -63,7 +63,7 @@ class RequestIndexer:
         if uid in self.update:
             del self.update[uid]
 
-    async def add(self, obj, indexes=None, modified=False, security=False):
+    async def add_object(self, obj, indexes=None, modified=False, security=False):
         uid = obj.uuid
         if modified:
             data = {}
@@ -144,7 +144,7 @@ def remove_object(obj, event):
     fut = get_request_indexer()
     if fut is None:
         return
-    fut.remove(obj)
+    fut.remove_object(obj)
 
 
 @configure.subscriber(
@@ -186,7 +186,7 @@ async def index_object(obj, indexes=None, modified=False, security=False):
     if fut is None:
         return
 
-    await fut.add(obj, indexes, modified, security)
+    await fut.add_object(obj, indexes, modified, security)
 
 
 @configure.subscriber(

--- a/guillotina/catalog/index.py
+++ b/guillotina/catalog/index.py
@@ -63,7 +63,7 @@ class RequestIndexer:
         if uid in self.update:
             del self.update[uid]
 
-    def add(self, obj, indexes=None, modified=False, security=False):
+    async def add(self, obj, indexes=None, modified=False, security=False):
         uid = obj.uuid
         if modified:
             data = {}
@@ -186,7 +186,7 @@ async def index_object(obj, indexes=None, modified=False, security=False):
     if fut is None:
         return
 
-    fut.add(obj, indexes, modified, security)
+    await fut.add(obj, indexes, modified, security)
 
 
 @configure.subscriber(

--- a/guillotina/catalog/index.py
+++ b/guillotina/catalog/index.py
@@ -1,4 +1,5 @@
 from guillotina import configure
+from guillotina._settings import app_settings
 from guillotina.catalog.utils import reindex_in_future
 from guillotina.component import query_adapter
 from guillotina.component import query_utility
@@ -16,7 +17,7 @@ from guillotina.utils import apply_coroutine
 from guillotina.utils import get_current_request
 
 
-class IndexFuture(object):
+class RequestIndexer:
 
     def __init__(self, container, request):
         self.remove = []
@@ -24,6 +25,13 @@ class IndexFuture(object):
         self.update = {}
         self.container = container
         self.request = request
+
+    @classmethod
+    def get(self, request):
+        return request.get_future('indexer')
+
+    def register(self, request):
+        request.add_future('indexer', self)
 
     async def __call__(self):
         if self.request.view_error:
@@ -44,8 +52,45 @@ class IndexFuture(object):
         self.update = {}
         self.remove = []
 
+    def reindex_security(self, obj):
+        reindex_in_future(obj, self.request, True)
 
-def get_future():
+    def remove(self, obj):
+        self.remove.append(obj)
+        uid = obj.uuid
+        if uid in self.index:
+            del self.index[uid]
+        if uid in self.update:
+            del self.update[uid]
+
+    def add(self, obj, indexes=None, modified=False, security=False):
+        uid = obj.uuid
+        if modified:
+            data = {}
+            if security:
+                adapter = query_adapter(obj, ISecurityInfo)
+                if adapter is not None:
+                    data = await apply_coroutine(adapter)
+            else:
+                if indexes is not None and len(indexes) > 0:
+                    search = query_utility(ICatalogUtility)
+                    if search is None:
+                        return
+                    data = await search.get_data(obj, indexes)
+            if len(data) > 0:
+                if uid in self.update:
+                    self.update[uid].update(data)
+                else:
+                    self.update[uid] = data
+        else:
+            self.index[uid] = await search.get_data(obj)
+
+
+# b/w compat
+IndexFuture = RequestIndexer
+
+
+def get_request_indexer():
 
     request = get_current_request()
     try:
@@ -57,11 +102,16 @@ def get_future():
     if not search:
         return  # no search configured
 
-    fut = request.get_future('indexer')
-    if fut is None:
-        fut = IndexFuture(container, request)
-        request.add_future('indexer', fut)
-    return fut
+    klass = app_settings['request_indexer']
+    indexer = klass.get(request)
+    if indexer is None:
+        indexer = klass(container, request)
+        indexer.register()
+    return indexer
+
+
+# b/w compat
+get_future = get_request_indexer
 
 
 @configure.subscriber(
@@ -71,16 +121,15 @@ async def security_changed(obj, event):
         # assuming permissions for group are already handled correctly with search
         await index_object(obj, modified=True, security=True)
         return
-    # We need to reindex the objects below
-    request = get_current_request()
-    reindex_in_future(obj, request, True)
+    fut = get_request_indexer()
+    fut.reindex_security(obj)
 
 
 @configure.subscriber(
     for_=(IResource, IObjectMovedEvent), priority=1000)
 def moved_object(obj, event):
-    request = get_current_request()
-    reindex_in_future(obj, request, True)
+    fut = get_request_indexer()
+    fut.reindex_security(obj)
 
 
 @configure.subscriber(for_=(IResource, IObjectRemovedEvent))
@@ -92,15 +141,10 @@ def remove_object(obj, event):
     if type_name is None or IContainer.providedBy(obj):
         return
 
-    fut = get_future()
+    fut = get_request_indexer()
     if fut is None:
         return
-
-    fut.remove.append(obj)
-    if uid in fut.index:
-        del fut.index[uid]
-    if uid in fut.update:
-        del fut.update[uid]
+    fut.remove(obj)
 
 
 @configure.subscriber(
@@ -138,30 +182,11 @@ async def index_object(obj, indexes=None, modified=False, security=False):
     if type_name is None or IContainer.providedBy(obj):
         return
 
-    search = query_utility(ICatalogUtility)
-    if search is None:
-        return
-
-    fut = get_future()
+    fut = get_request_indexer()
     if fut is None:
         return
 
-    if modified:
-        data = {}
-        if security:
-            adapter = query_adapter(obj, ISecurityInfo)
-            if adapter is not None:
-                data = await apply_coroutine(adapter)
-        else:
-            if indexes is not None and len(indexes) > 0:
-                data = await search.get_data(obj, indexes)
-        if len(data) > 0:
-            if uid in fut.update:
-                fut.update[uid].update(data)
-            else:
-                fut.update[uid] = data
-    else:
-        fut.index[uid] = await search.get_data(obj)
+    fut.add(obj, indexes, modified, security)
 
 
 @configure.subscriber(

--- a/guillotina/catalog/index.py
+++ b/guillotina/catalog/index.py
@@ -30,8 +30,8 @@ class RequestIndexer:
     def get(self, request):
         return request.get_future('indexer')
 
-    def register(self, request):
-        request.add_future('indexer', self)
+    def register(self):
+        self.request.add_future('indexer', self)
 
     async def __call__(self):
         if self.request.view_error:

--- a/guillotina/factory/app.py
+++ b/guillotina/factory/app.py
@@ -165,7 +165,8 @@ _dotted_name_settings = (
     'pg_connection_class',
     'oid_generator',
     'cors_renderer',
-    'check_writable_request'
+    'check_writable_request',
+    'request_indexer'
 )
 
 def optimize_settings(settings):

--- a/guillotina/security/utils.py
+++ b/guillotina/security/utils.py
@@ -45,7 +45,7 @@ def get_roles_with_access_content(obj, request=None):
 
 def get_principals_with_access_content(obj, request=None):
     if obj is None:
-        return {}
+        return []
     if request is None:
         request = get_current_request()
     interaction = IInteraction(request)

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -91,7 +91,7 @@ async def test_modified_event_gathers_all_index_data(dummy_request):
         'title': '',
         'id': ''
     }))
-    fut = index.get_future()
+    fut = index.get_request_indexer()
 
     assert len(fut.update['foobar']) == 5
 

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -9,9 +9,12 @@ from contextlib import contextmanager
 from guillotina._settings import app_settings
 from guillotina.auth.users import RootUser
 from guillotina.behaviors import apply_markers
+from guillotina.component import get_adapter
 from guillotina.content import Item
+from guillotina.interfaces import IAnnotations
 from guillotina.interfaces import IDefaultLayer
 from guillotina.interfaces import IRequest
+from guillotina.registry import REGISTRY_DATA_KEY
 from guillotina.request import Request
 from guillotina.security.policy import Interaction
 from guillotina.transactions import managed_transaction
@@ -67,6 +70,9 @@ async def get_container(requester=None, request=None, tm=None):
         if request is not None:
             request._container_id = container.id
             request.container = container
+            annotations_container = get_adapter(container, IAnnotations)
+            request.container_settings = await annotations_container.async_get(
+                REGISTRY_DATA_KEY)
         return container
 
 


### PR DESCRIPTION
Otherwise, there is no way to override how this is handled. This is one of the more painful type of integrations right now.

We could move to an adapter but then the integration doesn't get to decide if should register as an after commit hook or a future.