### PR TITLE
Provide `connection_settings` on the request object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Provide `connection_settings` on the request object with `tests.utils.get_container`
+  [vangheem]
 
 
 4.7.0 (2019-04-16)

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -9,9 +9,12 @@ from contextlib import contextmanager
 from guillotina._settings import app_settings
 from guillotina.auth.users import RootUser
 from guillotina.behaviors import apply_markers
+from guillotina.component import get_adapter
 from guillotina.content import Item
+from guillotina.interfaces import IAnnotations
 from guillotina.interfaces import IDefaultLayer
 from guillotina.interfaces import IRequest
+from guillotina.registry import REGISTRY_DATA_KEY
 from guillotina.request import Request
 from guillotina.security.policy import Interaction
 from guillotina.transactions import managed_transaction
@@ -67,6 +70,9 @@ async def get_container(requester=None, request=None, tm=None):
         if request is not None:
             request._container_id = container.id
             request.container = container
+            annotations_container = get_adapter(container, IAnnotations)
+            request.container_settings = await annotations_container.async_get(
+                REGISTRY_DATA_KEY)
         return container
 
 


### PR DESCRIPTION
 with `tests.utils.get_container`