### PR TITLE
Fix `managed_transaction` context manager to correctly adopt parent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 4.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix `managed_transaction` context manager to correctly adopt parent transaction
+  along with new transaction objects
+  [vangheem]
 
 
 4.7.6 (2019-04-28)

--- a/guillotina/tests/test_transactions.py
+++ b/guillotina/tests/test_transactions.py
@@ -1,7 +1,9 @@
+from guillotina.content import create_content_in_container
 from guillotina.db.transaction import Transaction
 from guillotina.tests import mocks
 from guillotina.tests import utils
 from guillotina.transactions import managed_transaction
+from guillotina.utils import get_object_by_oid
 
 
 async def test_no_tid_created_for_reads(dummy_request, loop):
@@ -43,3 +45,28 @@ async def test_managed_transaction_with_adoption(container_requester):
         async with managed_transaction(request=request, abort_when_done=True):
             container = await root.async_get('guillotina')
             assert container.title == 'changed title'
+
+
+async def test_managed_transaction_works_with_parent_txn_adoption(container_requester):
+    async with container_requester as requester:
+        request = utils.get_mocked_request(requester.db)
+        root = await utils.get_root(request)
+
+        async with managed_transaction(request=request):
+            # create some content
+            container = await root.async_get('guillotina')
+            await create_content_in_container(
+                container, 'Item', 'foobar', check_security=False, _p_oid='foobar')
+
+        async with managed_transaction(request=request):
+            container = await root.async_get('guillotina')
+
+            # nest it with adoption
+            async with managed_transaction(request=request, adopt_parent_txn=True) as txn:
+                ob = await get_object_by_oid('foobar', txn)
+                txn.delete(ob)
+
+        # finally, retrieve it again and make sure it's updated
+        async with managed_transaction(request=request):
+            container = await root.async_get('guillotina')
+            assert await container.async_get('foobar') is None

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -133,13 +133,19 @@ class managed_transaction:  # noqa: N801
             # where, we we're adopted those objects with this transaction
             if self.previous_txn != self.txn:
                 # try adopting currently registered objects
-                self.txn.modified = self.previous_txn.modified
-                self.txn.deleted = self.previous_txn.deleted
-                self.txn.added = self.previous_txn.added
+                self.txn.modified = {
+                    **self.previous_txn.modified,
+                    **self.txn.modified}
+                self.txn.deleted = {
+                    **self.previous_txn.deleted,
+                    **self.txn.deleted}
+                self.txn.added = {
+                    **self.previous_txn.added,
+                    **self.txn.added}
 
-                self.adopt_objects(self.txn.modified, self.txn)
-                self.adopt_objects(self.txn.deleted, self.txn)
-                self.adopt_objects(self.txn.added, self.txn)
+                self.adopt_objects(self.previous_txn.modified, self.txn)
+                self.adopt_objects(self.previous_txn.deleted, self.txn)
+                self.adopt_objects(self.previous_txn.added, self.txn)
 
         if self.abort_when_done:
             await self.tm.abort(txn=self.txn)


### PR DESCRIPTION
Otherwise right now, if you have a parent transaction you are adopting but modify/create data with the child transaction, it is overridden.