### PR TITLE
Get child item from deleted folder should be banned

### DIFF
--- a/guillotina/tests/test_utils.py
+++ b/guillotina/tests/test_utils.py
@@ -195,7 +195,7 @@ async def test_object_utils(container_requester):
         await request._tm.abort(txn=txn)
 
 
-async def test_get_deleted(container_requester):
+async def test_get_child_from_deleted(container_requester):
     async with container_requester as requester:
         response, status = await requester(
             'POST',


### PR DESCRIPTION
related issue #498 

This pr expose the problem, not fixed yet.

## Expected behavior

after delete the `folder`

- `get_object_by_oid(folder_oid)` return `None`
- `get_object_by_oid(item_oid)` return `None`

## Actual behavior

after delete the `folder`

- `get_object_by_oid(folder_oid)` return `None`
- `get_object_by_oid(item_oid)` return `Item` with None `__parent__`

## Steps to reproduce

see [commit@a2e4766](https://github.com/plone/guillotina/commit/a2e4766da2b4df63c3bb4582603edc5647ba0a7f)