### PR TITLE
get_object_by_oid should raise KeyError if object is tombstoned

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 CHANGELOG
 =========
 
-4.7.9 (unreleased)
+4.8.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- `get_object_by_oid` now raises KeyError since it provided unsafe behavior
+  when used with tombstoned objects
+  [vangheem]
 
 
 4.7.8 (2019-05-06)

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -785,8 +785,9 @@ async def invalidate_cache(context, request):
     })
 async def resolve_uid(context, request):
     uid = request.matchdict['uid']
-    ob = await get_object_by_oid(uid)
-    if ob is None:
+    try:
+        ob = await get_object_by_oid(uid)
+    except KeyError:
         return HTTPNotFound(content={
             'reason': f'Could not find uid: {uid}'
         })

--- a/guillotina/utils/content.py
+++ b/guillotina/utils/content.py
@@ -175,13 +175,10 @@ async def get_object_by_oid(oid: str, txn=None) -> typing.Optional[IResource]:
         txn = get_transaction()
     result = txn._manager._hard_cache.get(oid, None)
     if result is None:
-        try:
-            result = await txn._get(oid)
-        except KeyError:
-            return None
+        result = await txn._get(oid)
 
     if result['parent_id'] == TRASHED_ID:
-        return None
+        raise KeyError(oid)
 
     obj = reader(result)
     obj._p_jar = txn


### PR DESCRIPTION
Fixes https://github.com/plone/guillotina/issues/498