### PR TITLE
Cross role permissions issues

### DIFF
--- a/guillotina/auth/groups.py
+++ b/guillotina/auth/groups.py
@@ -1,5 +1,6 @@
 from guillotina import configure
 from guillotina.auth.users import GuillotinaUser
+from guillotina.interfaces import Allow
 from guillotina.interfaces import IGroups
 from guillotina.utils import get_current_request
 
@@ -11,11 +12,11 @@ class GuillotinaGroup(GuillotinaUser):
 
         if ident == 'Managers':
             # Special Case its a Root Manager user
-            self._roles['guillotina.ContainerAdmin'] = 1
-            self._roles['guillotina.ContainerDeleter'] = 1
-            self._roles['guillotina.Owner'] = 1
-            self._roles['guillotina.Member'] = 1
-            self._roles['guillotina.Manager'] = 1
+            self._roles['guillotina.ContainerAdmin'] = Allow
+            self._roles['guillotina.ContainerDeleter'] = Allow
+            self._roles['guillotina.Owner'] = Allow
+            self._roles['guillotina.Member'] = Allow
+            self._roles['guillotina.Manager'] = Allow
 
 
 @configure.utility(provides=IGroups)

--- a/guillotina/auth/participation.py
+++ b/guillotina/auth/participation.py
@@ -29,7 +29,7 @@ class GuillotinaParticipation(object):
                 self.request._cache_user = user
                 self.principal = user
                 if hasattr(user, 'roles') and 'guillotina.Authenticated' not in user.roles:
-                    user.roles['guillotina.Authenticated'] = 1
+                    user.roles['guillotina.Authenticated'] = Allow
         else:
             self.principal = getattr(self.request, '_cache_user', None)
         self.interaction = None

--- a/guillotina/security/utils.py
+++ b/guillotina/security/utils.py
@@ -37,7 +37,9 @@ def get_roles_with_access_content(obj, request=None):
     roles = interaction.cached_roles(obj, 'guillotina.AccessContent', 'o')
     result = []
     all_roles = role.global_roles() + role.local_roles()
-    for r in roles.keys():
+    for r, v in roles.items():
+        if v != 1:
+            continue
         if r in all_roles:
             result.append(r)
     return result
@@ -52,7 +54,9 @@ def get_principals_with_access_content(obj, request=None):
     roles = interaction.cached_roles(obj, 'guillotina.AccessContent', 'o')
     result = []
     all_roles = role.global_roles() + role.local_roles()
-    for r in roles.keys():
+    for r, v in roles.items():
+        if v != 1:
+            continue
         if r in all_roles:
             result.append(r)
     users = interaction.cached_principals(obj, result, 'guillotina.AccessContent', 'o')


### PR DESCRIPTION
## Problem
Deny/Allow permissions assigned to multiple roles the user has are not properly applied.

This test demonstrates the issue.

I attempted to fix it only to realize there are other cases we won't cover.

So fixing it completely would introduce a lot of complexity I think.

Do you have any thoughts on it? Am I misunderstanding something?

## How it currently fails

- /db/container/folder [Allow: guillotina.DeleteContent to guillotina.Member]
- /db/container/folder/item [Deny: guillotina.DeleteContent to guillotina.Anonymous]

The roles used here can be changed with anything.

In this case the user will still be able to delete the item even though they have been specifically denied.

My PR fixes the above use-case only to ruin the reverse use case where allow is done on the child and deny done on the parent.