### PR TITLE
Support zope.Interface inheritance in schema.Object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support zope.Interface inheritance in schema.Object
+  [masipcat]
 
 
 4.8.0 (2019-05-13)

--- a/guillotina/schema/_field.py
+++ b/guillotina/schema/_field.py
@@ -604,7 +604,7 @@ class Object(Field):
             # Dicts are validated differently
             valid_type = namedtuple(
                 'temp_validate_type',
-                set(self.schema.names()) & set(value.keys()))
+                set(self.schema.names(all=True)) & set(value.keys()))
             # check the value against schema
             errors = _validate_fields(self.schema, valid_type(**value))
         else:

--- a/guillotina/schema/tests/test__field.py
+++ b/guillotina/schema/tests/test__field.py
@@ -1792,6 +1792,29 @@ class ObjectTests(unittest.TestCase):
         objf = self._makeOne(schema)
         objf.validate(OK())  # doesn't raise
 
+    def test__validate_interface_inheritance(self):
+        from guillotina.schema import Int, Object
+        from zope.interface import implementer
+        from zope.interface import Interface
+
+        class IFoo(Interface):
+            foo=Int()
+
+        class IBar(Interface):
+            bar=Int()
+
+        class IFooBar(IFoo, IBar):
+            pass
+
+        IContentType = self._makeSchema(foobar=Object(schema=IFooBar))
+
+        @implementer(IContentType)
+        class OK(object):
+            foobar = {"foo": 1, "bar": 2}
+
+        objf = self._makeOne(IContentType)
+        objf.validate(OK())  # doesn't raise
+
     def test_validate_w_cycles(self):
         IUnit, Person, Unit = self._makeCycles()
         field = self._makeOne(schema=IUnit)


### PR DESCRIPTION
Hi!

I'm opening this PR to fix a small error on `schema.Object._validate()` when using a `zope.Internface` with inheritance as schema.

Example:

```python
class IFoo(Interface):
    foo = schema.Int()


class IBar(Interface):
    bar = schema.Int()


class IFooBar(IFoo, IBar):
    pass


class IMainContent(Interface):
    foobar = schema.Object(schema=IFooBar)
```

The problem appears when Guillotina validates the payload with the schema:

payload:
```json
{
    "foobar": {"foo": 1, "bar": 2}
}
```

Traceback:
```
  ...
  File "/home/jordi/gits/api/venv/lib/python3.7/site-packages/guillotina/schema/_bootstrapfields.py", line 179, in validate
    self._validate(value)
  File "/home/jordi/gits/api/venv/lib/python3.7/site-packages/guillotina/schema/_field.py", line 615, in _validate
    errors = _validate_fields(self.schema, valid_type(**value))
TypeError: __new__() got an unexpected keyword argument 'foo'
```