### PR TITLE
add mappings to test field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 4.8.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add field mappings for test field [lferran]
 
 
 4.8.6 (2019-06-10)

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -47,6 +47,7 @@ class ContextDefaultFactory:
 
 CATEGORIES_MAPPING = {
     'dynamic': False,
+    'type': 'nested',
 }
 
 
@@ -54,7 +55,7 @@ class IExample(IResource):
 
     metadata('categories')
 
-    index_field('categories', type='nested', field_mapping=CATEGORIES_MAPPING)
+    index_field('categories', field_mapping=CATEGORIES_MAPPING)
     categories = schema.List(
         title='categories',
         default=[],

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -45,11 +45,16 @@ class ContextDefaultFactory:
         return 'foobar'
 
 
+CATEGORIES_MAPPING = {
+    'dynamic': False,
+}
+
+
 class IExample(IResource):
 
     metadata('categories')
 
-    index_field('categories', type='nested')
+    index_field('categories', type='nested', field_mapping=CATEGORIES_MAPPING)
     categories = schema.List(
         title='categories',
         default=[],


### PR DESCRIPTION
I need this to migrate guillotina_elasticsearch to support 7.0
Otherwise I get this:
```
utility.py  
519 ERROR    Error indexing: 
{'took': 30, 'errors': True, 'items': [{'index': {'_index': 'guillotina-db-guillotina_1', '_type': '_doc', '_id': '309|213349c8307243e494b38e09b868f2e7', 'status': 400, 'error': {'type': 'strict_dynamic_mapping_exception', 'reason': 'mapping set to strict, dynamic introduction of [label] within [categories] is not allowed'}}}]}

```