### PR TITLE
[4.x] Index data missing from content when accessor does not specify "fields"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,9 @@ deploy:
   script: bash docker_push
   on:
     tags: true
+
+# safelist
+branches:
+  only:
+  - master
+  - 4.x

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ CHANGELOG
 4.8.10 (unreleased)
 -------------------
 
+- Fix indexing data potentially missing updated content when `fields` for accessor
+  is not specified
+  [vangheem]
+
 - Fix events antipattern [lferran]
 
 4.8.9 (2019-06-17)

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -170,7 +170,7 @@ class DefaultCatalogDataAdapter(object):
                     # accessors we always reindex since we can't know if updated
                     # from the indexes param--they are "fake" like indexes, not fields
                     if 'accessor' in index_data:
-                        if (indexes is None or
+                        if (indexes is None or not index_data.get('fields', []) or
                                 (len(set(index_data.get('fields', [])) & set(indexes)) > 0)):
                             if not loaded:
                                 await self.load_behavior(behavior)

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -170,7 +170,7 @@ class DefaultCatalogDataAdapter(object):
                     # accessors we always reindex since we can't know if updated
                     # from the indexes param--they are "fake" like indexes, not fields
                     if 'accessor' in index_data:
-                        if (indexes is None or not index_data.get('fields', []) or
+                        if (indexes is None or not index_data.get('fields') or
                                 (len(set(index_data.get('fields', [])) & set(indexes)) > 0)):
                             if not loaded:
                                 await self.load_behavior(behavior)

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -1,7 +1,4 @@
 # this is for testing.py, do not import into other modules
-import json
-from guillotina.schema.interfaces import IContextAwareDefaultFactory
-
 from guillotina import configure
 from guillotina import schema
 from guillotina.async_util import IAsyncUtility
@@ -12,6 +9,7 @@ from guillotina.content import Resource
 from guillotina.directives import index_field
 from guillotina.directives import metadata
 from guillotina.directives import write_permission
+from guillotina.exceptions import NoIndexField
 from guillotina.fields import CloudFileField
 from guillotina.interfaces import IApplication
 from guillotina.interfaces import IContainer
@@ -20,8 +18,11 @@ from guillotina.interfaces import IItem
 from guillotina.interfaces import IObjectAddedEvent
 from guillotina.interfaces import IResource
 from guillotina.response import HTTPUnprocessableEntity
-from zope.interface import Interface
+from guillotina.schema.interfaces import IContextAwareDefaultFactory
 from zope.interface import implementer
+from zope.interface import Interface
+
+import json
 
 
 app_settings = {
@@ -87,6 +88,22 @@ class IExample(IResource):
     context_default_factory_test = schema.Text(
         defaultFactory=ContextDefaultFactory()
     )
+
+
+@index_field.with_accessor(
+    IExample, 'categories_accessor', field='categories')
+def categories_index_accessor(ob):
+    if not ob.categories:
+        raise NoIndexField
+    else:
+        return [
+            c['label'] for c in ob.categories
+        ]
+
+
+@index_field.with_accessor(IExample, 'foobar_accessor')
+def foobar_accessor(ob):
+    return 'foobar'
 
 
 configure.permission('example.MyPermission', 'example permission')

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -100,9 +100,9 @@ async def test_get_data_uses_indexes_param(dummy_request):
     container.__name__ = 'guillotina'
     ob = await create_content('Item', id='foobar')
     data = await util.get_data(ob, indexes=['title'])
-    assert len(data) == 4  # uuid, type_name, etc always returned
+    assert len(data) == 7  # uuid, type_name, etc always returned
     data = await util.get_data(ob, indexes=['title', 'id'])
-    assert len(data) == 5
+    assert len(data) == 8
 
     data = await util.get_data(ob)
     assert len(data) > 9
@@ -124,12 +124,12 @@ async def test_modified_event_gathers_all_index_data(dummy_request):
     }))
     fut = index.get_request_indexer()
 
-    assert len(fut.update['foobar']) == 5
+    assert len(fut.update['foobar']) == 8
 
     await notify(ObjectModifiedEvent(ob, payload={
         'creation_date': ''
     }))
-    assert len(fut.update['foobar']) == 6
+    assert len(fut.update['foobar']) == 9
 
 
 async def test_search_endpoint(container_requester):

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -45,6 +45,37 @@ async def test_get_index_data(dummy_request):
     assert 'title' in fields
 
 
+async def test_get_index_data_with_accessors(dummy_request):
+    request = dummy_request  # noqa
+
+    container = await create_content(
+        'Container',
+        id='guillotina',
+        title='Guillotina')
+    container.__name__ = 'guillotina'
+
+    ob = await create_content('Example', id='foobar', categories=[{
+        'label': 'foo',
+        'number': 1
+    }])
+
+    data = ICatalogDataAdapter(ob)
+    fields = await data()
+    for field_name in ('categories_accessor', 'foobar_accessor', 'type_name',
+                       'categories', 'uuid', 'path', 'title', 'tid'):
+        assert field_name in fields
+
+    # now only with indexes specified
+    data = ICatalogDataAdapter(ob)
+    fields = await data(indexes=['categories'])
+    # but should also pull in `foobar_accessor` because it does not
+    # have a field specified for it.
+    for field_name in ('categories_accessor', 'foobar_accessor', 'type_name',
+                       'categories', 'uuid', 'tid'):
+        assert field_name in fields
+    assert 'title' not in fields
+
+
 async def test_registered_base_utility(dummy_request):
     util = query_utility(ICatalogUtility)
     assert util is not None


### PR DESCRIPTION
The behavior was supposed to be if no fields were specified it'd always pull the data.

I don't know how we never got hit by this worse.