### PR TITLE
[4.x] Handle CancelledError on application cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.8.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Handle CancelledError on application cleanup. This seems to happen with uvloop
+  [vangheem]
 
 
 4.8.11 (2019-06-28)

--- a/guillotina/commands/__init__.py
+++ b/guillotina/commands/__init__.py
@@ -185,8 +185,11 @@ class Command(object):
             # Blocking call which returns when finished
             loop = asyncio.get_event_loop()
             loop.run_until_complete(self.run(self.arguments, settings, app))
-            loop.run_until_complete(self.cleanup(app))
-            loop.close()
+            try:
+                loop.run_until_complete(self.cleanup(app))
+                loop.close()
+            except (asyncio.CancelledError, RuntimeError):
+                logger.warning('Cancelled error on cleanup')
         else:
             self.run(self.arguments, settings, app)
 


### PR DESCRIPTION
this seems to happen with uvloop