### PR TITLE
Fix redis pubsub potential cpu bound deadlock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.0.0a11 (unreleased)
 ---------------------
 
+- Fix redis pubsub potential cpu bound deadlock
+  [vangheem]
+
 - Handle cancelled error on cleanup
   [vangheem]
 

--- a/guillotina/contrib/pubsub/utility.py
+++ b/guillotina/contrib/pubsub/utility.py
@@ -42,9 +42,9 @@ class PubSubUtility:
         await asyncio.sleep(0.1)
 
     async def real_subscribe(self, channel_name):
-        channel = await self._driver.subscribe(channel_name)
         try:
             while channel_name in self._subscribers:
+                channel = await self._driver.subscribe(channel_name)
                 async for msg in channel:
                     try:
                         data = pickle.loads(msg)


### PR DESCRIPTION
aioredis pubsub is potentially dangerous here.

https://github.com/aio-libs/aioredis/blob/master/aioredis/pubsub.py#L57 -- when a connection is closed, the channel object will be continuously run this over and over again in the while loop.

You need to recreate the subscription inside the `while channel_name in self._subscribers:` block otherwise, `async for msg in channel:` will exit continuously and block your app from doing anything.