### PR TITLE
[4.x] Improve request handling memory usage.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.8.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve request memory usage
+  [vangheem]
 
 
 4.8.13 (2019-07-15)

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -266,6 +266,10 @@ def _clean_request(request, response):
         if getattr(request, attr, None) is not None:
             setattr(request, attr, None)
 
+    for attr in ('_cache_data', '_last_read_pos',):
+        if hasattr(request, attr):
+            delattr(request, attr)
+
 
 class MatchInfo(BaseMatchInfo):
     """Function that returns from traversal request on aiohttp."""


### PR DESCRIPTION
Because of all the references placed on request objects like `.resource` and `.found_view`,
python was not able to garbage collect those objects.

asyncio keeps task objects around. These task objects reference requests. Additionally,
these request objects might be passed around and used elsewhere.

Even worse, if an exception was thrown, the stack frame + variables also prevented
content objects from eagerly getting garbage collected. I imagine the real problem
is that because of the structure of the request handling caused reference cycles(
objects that transiently reference each other). These reference cycles are not often
garbage collected by python.

Explicitly deleting these attributes improves memory performance significantly
when running multiple requests.

Additionally, maintaining references to exception objects is potentially very dangerous.
Exceptions objects include a `__traceback__` object which has references to all the
variables in the frames of the exception.

I have local test scenarios where without this change, active memory will keep
climbing over a couple gigabytes of data. With this in place, it maintains steady
around 150mb.