### PR TITLE
[4.x] Fix `modification_date` not indexed when an object is patched

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - pip install Cython==0.27.3
   - pip install -r requirements.txt
   - pip install -e .[test]
-  - pip install flake8==3.7.7 codecov mypy==0.670 mypy-zope
+  - pip install flake8==3.7.7 codecov mypy==0.670 mypy-zope==0.1.3
   - sleep 5
 script:
   - flake8 guillotina --config=setup.cfg

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 4.9.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix `modification_date` not indexed when an object is patched
+  [masipcat]
 
 
 4.9.2 (2019-08-06)

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -112,7 +112,8 @@ class DefaultSecurityInfoAdapter(object):
             'access_users': get_principals_with_access_content(self.content),
             'access_roles': get_roles_with_access_content(self.content),
             'type_name': self.content.type_name,
-            'tid': self.content._p_serial
+            'tid': self.content._p_serial,
+            'modification_date': self.content.modification_date,
         }
 
 
@@ -149,7 +150,8 @@ class DefaultCatalogDataAdapter(object):
         # For each type
         values = {
             'type_name': self.content.type_name,
-            'tid': self.content._p_serial
+            'tid': self.content._p_serial,
+            'modification_date': self.content.modification_date,
         }
         if schemas is None:
             schemas = iter_schemata(self.content)

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -100,12 +100,12 @@ async def test_get_data_uses_indexes_param(dummy_request):
     container.__name__ = 'guillotina'
     ob = await create_content('Item', id='foobar')
     data = await util.get_data(ob, indexes=['title'])
-    assert len(data) == 7  # uuid, type_name, etc always returned
+    assert len(data) == 8  # uuid, type_name, etc always returned
     data = await util.get_data(ob, indexes=['title', 'id'])
-    assert len(data) == 8
+    assert len(data) == 9
 
     data = await util.get_data(ob)
-    assert len(data) > 9
+    assert len(data) > 10
 
 
 async def test_modified_event_gathers_all_index_data(dummy_request):
@@ -124,12 +124,13 @@ async def test_modified_event_gathers_all_index_data(dummy_request):
     }))
     fut = index.get_request_indexer()
 
-    assert len(fut.update['foobar']) == 8
+    assert len(fut.update['foobar']) == 9
 
     await notify(ObjectModifiedEvent(ob, payload={
         'creation_date': ''
     }))
-    assert len(fut.update['foobar']) == 9
+    assert 'modification_date' in fut.update['foobar']
+    assert len(fut.update['foobar']) == 10
 
 
 async def test_search_endpoint(container_requester):


### PR DESCRIPTION
Closes https://github.com/plone/guillotina/issues/631