### PR TITLE
[master] Fix `modification_date` not indexed when an object is patched

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,12 @@ CHANGELOG
 5.0.0a16 (unreleased)
 ---------------------
 
+- Fix `modification_date` not indexed when an object is patched
+  [masipcat]
+
 - Refractor SwaggerUI and to use in built auth of SwaggerUI
 
-- Getting OpenAPI js and css from CDN 
+- Getting OpenAPI js and css from CDN
 
 - Doc edit for OpenAPI
 

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -135,7 +135,8 @@ class DefaultSecurityInfoAdapter(object):
             'access_users': get_principals_with_access_content(self.content),
             'access_roles': get_roles_with_access_content(self.content),
             'type_name': self.content.type_name,
-            'tid': self.content.__serial__
+            'tid': self.content.__serial__,
+            'modification_date': self.content.modification_date,
         }
 
 
@@ -172,7 +173,8 @@ class DefaultCatalogDataAdapter(object):
         # For each type
         values = {
             'type_name': self.content.type_name,
-            'tid': self.content.__serial__
+            'tid': self.content.__serial__,
+            'modification_date': self.content.modification_date,
         }
         if schemas is None:
             schemas = iter_schemata(self.content)

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -115,12 +115,13 @@ async def test_get_data_uses_indexes_param(dummy_guillotina):
     container.__name__ = 'guillotina'
     ob = await create_content('Item', id='foobar')
     data = await util.get_data(ob, indexes=['title'])
-    assert len(data) == 7  # @uid, type_name, etc always returned
+    assert len(data) == 8  # @uid, type_name, etc always returned
+
     data = await util.get_data(ob, indexes=['title', 'id'])
-    assert len(data) == 8
+    assert len(data) == 9
 
     data = await util.get_data(ob)
-    assert len(data) > 9
+    assert len(data) > 10
 
 
 async def test_modified_event_gathers_all_index_data(dummy_guillotina):
@@ -138,12 +139,13 @@ async def test_modified_event_gathers_all_index_data(dummy_guillotina):
     }))
     fut = index.get_indexer()
 
-    assert len(fut.update['foobar']) == 8
+    assert len(fut.update['foobar']) == 9
 
     await notify(ObjectModifiedEvent(ob, payload={
         'creation_date': ''
     }))
-    assert len(fut.update['foobar']) == 9
+    assert 'modification_date' in fut.update['foobar']
+    assert len(fut.update['foobar']) == 10
 
 
 @pytest.mark.app_settings(PG_CATALOG_SETTINGS)


### PR DESCRIPTION
Closes https://github.com/plone/guillotina/issues/631