### PR TITLE
Fix `modification_date` not indexed when an object is patched

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.0.0a16 (unreleased)
 ---------------------
 
+- Fix `modification_date` not indexed when an object is patched
+  [masipcat]
+
 - Move to black code formatter
   [vangheem]
 

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -125,6 +125,7 @@ class DefaultSecurityInfoAdapter(object):
             "access_roles": get_roles_with_access_content(self.content),
             "type_name": self.content.type_name,
             "tid": self.content.__serial__,
+            "modification_date": json_compatible(self.content.modification_date),
         }
 
 
@@ -156,7 +157,11 @@ class DefaultCatalogDataAdapter(object):
 
     async def __call__(self, indexes=None, schemas=None):
         # For each type
-        values = {"type_name": self.content.type_name, "tid": self.content.__serial__}
+        values = {
+            "type_name": self.content.type_name,
+            "tid": self.content.__serial__,
+            "modification_date": json_compatible(self.content.modification_date),
+        }
         if schemas is None:
             schemas = iter_schemata(self.content)
 

--- a/guillotina/contrib/catalog/pg.py
+++ b/guillotina/contrib/catalog/pg.py
@@ -54,10 +54,17 @@ app_settings = {
 
 # 2019-06-15T18:37:31.008359+00:00
 PG_FUNCTIONS = [
-    """CREATE OR REPLACE FUNCTION f_cast_isots(text)
-  RETURNS timestamptz AS
-$$SELECT CAST($1 AS timestamptz)$$  -- adapt to your needs
-  LANGUAGE sql IMMUTABLE;"""
+    """CREATE OR REPLACE FUNCTION f_cast_isots(text) RETURNS timestamptz AS $$
+begin
+    return CAST($1 AS timestamptz);
+exception
+    when invalid_text_representation then
+        return CAST('1970-01-01T00:00:00Z' AS timestamptz);
+    when datetime_field_overflow then
+        return CAST('1970-01-01T00:00:00Z' AS timestamptz);
+end;
+$$ language plpgsql immutable;
+"""
 ]
 
 # Reindex logic

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -110,12 +110,12 @@ async def test_get_data_uses_indexes_param(dummy_guillotina):
     container.__name__ = "guillotina"
     ob = await create_content("Item", id="foobar")
     data = await util.get_data(ob, indexes=["title"])
-    assert len(data) == 7  # @uid, type_name, etc always returned
+    assert len(data) == 8  # @uid, type_name, etc always returned
     data = await util.get_data(ob, indexes=["title", "id"])
-    assert len(data) == 8
+    assert len(data) == 9
 
     data = await util.get_data(ob)
-    assert len(data) > 9
+    assert len(data) > 10
 
 
 async def test_modified_event_gathers_all_index_data(dummy_guillotina):
@@ -127,10 +127,11 @@ async def test_modified_event_gathers_all_index_data(dummy_guillotina):
     await notify(ObjectModifiedEvent(ob, payload={"title": "", "id": ""}))
     fut = index.get_indexer()
 
-    assert len(fut.update["foobar"]) == 8
+    assert len(fut.update["foobar"]) == 9
 
     await notify(ObjectModifiedEvent(ob, payload={"creation_date": ""}))
-    assert len(fut.update["foobar"]) == 9
+    assert "modification_date" in fut.update["foobar"]
+    assert len(fut.update["foobar"]) == 10
 
 
 @pytest.mark.app_settings(PG_CATALOG_SETTINGS)


### PR DESCRIPTION
@masipcat I had a look at https://github.com/plone/guillotina/pull/633

Problem was serialization. ujson auto converts date fields to epoch where we use iso date format. jsonb index was expecting iso format too.