### PR TITLE
[4.x] Fix cache key for SQLStatements cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 4.9.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix cache key for SQLStatements cache. This was causing vacuuming on multi-db environments
+  to not work since the vacuuming object was shared between dbs on guillotina_dynamictablestorage.
+  [vangheem]
 
 
 4.9.5 (2019-08-21)

--- a/guillotina/db/storages/utils.py
+++ b/guillotina/db/storages/utils.py
@@ -31,8 +31,9 @@ class SQLStatements:
         self._cached = {}
 
     def get(self, name, table_name):
-        if name in self._cached:
-            return self._cached[name]
+        key = name + '::' + table_name
+        if key in self._cached:
+            return self._cached[key]
         sql = _statements[name].format(table_name=table_name)
-        self._cached[name] = sql
+        self._cached[key] = sql
         return sql


### PR DESCRIPTION
This was causing vacuuming on multi-db environments to not work since the vacuuming object was shared between dbs on guillotina_dynamictablestorage.