### PR TITLE
Proposal: remove __txn__ from object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ CHANGELOG
 5.0.0a16 (unreleased)
 ---------------------
 
+- Remove IBaseObject.__txn__, IBaseObject.register, explicitly use `ITransaction.register` now
+  [vangheem]
+
+- No longer attempt to reuse a transaction object(unnecessary optimization)
+  [vangheem]
+
 - Fix cache key for SQLStatements cache. This was causing vacuuming on multi-db environments
   to not work since the vacuuming object was shared between dbs on guillotina_dynamictablestorage.
   [vangheem]

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -56,6 +56,7 @@ from guillotina.security.utils import apply_sharing
 from guillotina.transactions import get_transaction
 from guillotina.utils import get_authenticated_user_id
 from guillotina.utils import get_behavior
+from guillotina.utils import get_current_transaction
 from guillotina.utils import get_object_by_uid
 from guillotina.utils import get_object_url
 from guillotina.utils import get_security_policy
@@ -457,7 +458,7 @@ class DefaultDELETE(Service):
         content_id = self.context.id
         parent = self.context.__parent__
         await notify(BeforeObjectRemovedEvent(self.context, parent, content_id))
-        self.context.__txn__.delete(self.context)
+        get_current_transaction().delete(self.context)
         await notify(ObjectRemovedEvent(self.context, parent, content_id))
 
 

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -547,7 +547,7 @@ async def create_content(type_, **kw) -> IResource:
 
 @profilable
 async def create_content_in_container(
-    parent: Folder, type_: str, id_: str, request: IRequest = None, check_security=True, **kw
+    parent: Folder, type_: str, id_: str, check_security=True, **kw
 ) -> Resource:
     """Utility to create a content.
 
@@ -557,7 +557,6 @@ async def create_content_in_container(
     :param parent: where to create content inside of
     :param type_: content type to create
     :param id_: id to give content in parent object
-    :param request: <optional>
     :param check_security: be able to disable security checks
     """
     factory = get_cached_factory(type_)

--- a/guillotina/contrib/catalog/pg.py
+++ b/guillotina/contrib/catalog/pg.py
@@ -649,7 +649,6 @@ class PGSearchUtility(DefaultSearchUtility):
             return
 
         data["transaction"] = await data["tm"].begin()
-        container.__txn__ = data["transaction"]
         await self._process_object(container, data)
         await self._process_folder(container, data)
         await data["tm"].commit(txn=data["transaction"])
@@ -668,8 +667,7 @@ class PGSearchUtility(DefaultSearchUtility):
 
         if data["count"] % 200 == 0:
             await data["tm"].commit(txn=data["transaction"])
-            data["transaction"] = await data["tm"].begin()
-            obj.__txn__ = data["transaction"]
+            await data["tm"].begin(txn=data["transaction"])
 
         uuid = obj.__uuid__
 

--- a/guillotina/db/orm/base.py
+++ b/guillotina/db/orm/base.py
@@ -1,4 +1,3 @@
-from guillotina.db.interfaces import ITransaction
 from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.profile import profilable
 from typing import Any
@@ -7,8 +6,6 @@ from typing import Generic
 from typing import Optional
 from typing import TypeVar
 from zope.interface import implementer
-
-import weakref
 
 
 T = TypeVar("T")

--- a/guillotina/db/orm/base.py
+++ b/guillotina/db/orm/base.py
@@ -1,10 +1,14 @@
-from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.db.interfaces import ITransaction
+from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.profile import profilable
 from typing import Any
 from typing import Dict
-from typing import Optional, Generic, TypeVar
+from typing import Generic
+from typing import Optional
+from typing import TypeVar
 from zope.interface import implementer
+
+import weakref
 
 
 T = TypeVar("T")
@@ -87,17 +91,16 @@ class BaseObject:
     __immutable_cache__: bool = ObjectProperty[bool]("_BaseObject__immutable_cache", False)  # type: ignore
     __new_marker__: bool = ObjectProperty[bool]("_BaseObject__new_marker", False)  # type: ignore
     __gannotations__: Dict = DictDefaultProperty("_BaseObject__annotations")  # type: ignore
-    __txn__: Optional[ITransaction] = ObjectProperty[Optional[ITransaction]](  # type: ignore
-        "_BaseObject__txn", None
-    )
+
     __uuid__: str = ObjectProperty[str]("_BaseObject__uuid", None)  # type: ignore
     __serial__: int = ObjectProperty[int]("_BaseObject__serial", None)  # type: ignore
     __volatile__: Dict = DictDefaultProperty("_BaseObject__volatile")  # type: ignore
 
     def register(self):
-        txn = self.__txn__
-        if txn is not None:
-            txn.register(self)
+        from guillotina.utils import get_current_transaction
+
+        txn = get_current_transaction()
+        txn.register(self)
 
     @profilable
     def __getstate__(self):

--- a/guillotina/db/orm/interfaces.py
+++ b/guillotina/db/orm/interfaces.py
@@ -13,19 +13,6 @@ class IBaseObject(Interface):
     __name__ = Attribute("")
     __parent__ = Attribute("")
 
-    __txn__ = Attribute(
-        """The data manager for the object.
-
-        The data manager should implement IPersistentDataManager (note that
-        this constraint is not enforced).
-
-        If there is no data manager, then this is None.
-
-        Once assigned to a data manager, an object cannot be re-assigned
-        to another.
-        """
-    )
-
     __uuid__ = Attribute(
         """The object id.
 

--- a/guillotina/registry.py
+++ b/guillotina/registry.py
@@ -3,6 +3,7 @@ from guillotina.browser import get_physical_path
 from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.interfaces import IRegistry
 from guillotina.schema._bootstrapinterfaces import IContextAwareDefaultFactory
+from guillotina.utils import get_current_transaction
 from zope.interface import alsoProvides
 from zope.interface import implementer
 
@@ -67,7 +68,7 @@ class Registry(AnnotationData):
 
     def __setitem__(self, name, value):
         super(Registry, self).__setitem__(name, value)
-        self.register()
+        get_current_transaction().register(self)
 
     def for_interface(self, iface, check=True, omit=(), prefix=None):
         return RecordsProxy(self, iface, prefix=prefix)

--- a/guillotina/tests/mocks.py
+++ b/guillotina/tests/mocks.py
@@ -1,4 +1,3 @@
-import asyncio
 import uuid
 
 from guillotina import task_vars
@@ -34,7 +33,6 @@ class MockTransaction:
             self, ITransactionStrategy, name=manager._storage._transaction_strategy
         )
         self._cache = DummyCache(self)
-        self._lock = asyncio.Lock()
         self._status = "started"
         self._db_conn = None
         self.storage = MockStorage()
@@ -169,7 +167,6 @@ class FakeConnection:
         return key in [self.refs[oid].id for oid in oids]
 
     def register(self, ob):
-        ob.__txn__ = self
         ob.__uuid__ = uuid.uuid4().hex
         self.refs[ob.__uuid__] = ob
         self.containments[ob.__uuid__] = []

--- a/guillotina/tests/mocks.py
+++ b/guillotina/tests/mocks.py
@@ -1,5 +1,3 @@
-import uuid
-
 from guillotina import task_vars
 from guillotina.component import query_adapter
 from guillotina.db.cache.dummy import DummyCache
@@ -8,6 +6,9 @@ from guillotina.db.interfaces import ITransaction
 from guillotina.db.interfaces import ITransactionStrategy
 from guillotina.db.interfaces import IWriter
 from zope.interface import implementer
+
+import asyncio
+import uuid
 
 
 class MockDBTransaction:
@@ -85,6 +86,14 @@ class MockStorage:
         self._misses = 0
         self._stored = 0
         self._objects_table_name = "objects"
+        self.__lock = None
+
+    @property
+    def _lock(self):
+        # lazy create lock
+        if self.__lock is None:
+            self.__lock = asyncio.Lock()
+        return self.__lock
 
     async def get_annotation(self, trns, oid, id):
         return None

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -14,7 +14,6 @@ from guillotina.interfaces.types import IConstrainTypes
 from guillotina.schema import Dict
 from guillotina.schema import TextLine
 from guillotina.test_package import ITestBehavior
-from guillotina.tests.mocks import MockTransaction
 from guillotina.tests import utils
 from guillotina.transactions import transaction
 from guillotina.utils import get_behavior

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -1,14 +1,10 @@
-import json
-import pickle
-
-import pytest
 from guillotina import configure
 from guillotina.behaviors.dublincore import IDublinCore
 from guillotina.component import get_utility
-from guillotina.content import Folder
-from guillotina.content import Item
 from guillotina.content import create_content
 from guillotina.content import create_content_in_container
+from guillotina.content import Folder
+from guillotina.content import Item
 from guillotina.content import load_cached_schema
 from guillotina.exceptions import NoPermissionToAdd
 from guillotina.exceptions import NotAllowedContentType
@@ -18,9 +14,15 @@ from guillotina.interfaces.types import IConstrainTypes
 from guillotina.schema import Dict
 from guillotina.schema import TextLine
 from guillotina.test_package import ITestBehavior
+from guillotina.tests.mocks import MockTransaction
 from guillotina.tests import utils
+from guillotina.transactions import transaction
 from guillotina.utils import get_behavior
 from guillotina.utils import get_object_by_oid
+
+import json
+import pickle
+import pytest
 
 
 class ICustomContentType(IItem):
@@ -33,90 +35,96 @@ class CustomContentType(Item):
     pass
 
 
-async def test_not_allowed_to_create_content(dummy_guillotina):
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
+async def test_not_allowed_to_create_content(db):
+    async with transaction(db=db):
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
 
-    with pytest.raises(NoPermissionToAdd):
-        # not logged in, can't create
+        with pytest.raises(NoPermissionToAdd):
+            # not logged in, can't create
+            await create_content_in_container(container, "Item", id_="foobar")
+
+
+async def test_allowed_to_create_content(db):
+    utils.login()
+
+    async with transaction(db=db):
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
+        utils.register(container)
+
         await create_content_in_container(container, "Item", id_="foobar")
 
 
-async def test_allowed_to_create_content(dummy_guillotina):
+async def test_allowed_types(db):
     utils.login()
 
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
-    utils.register(container)
+    async with transaction(db=db):
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
+        utils.register(container)
 
-    await create_content_in_container(container, "Item", id_="foobar")
+        import guillotina.tests
+
+        configure.register_configuration(
+            Folder,
+            dict(
+                type_name="TestType",
+                allowed_types=["Item"],
+                module=guillotina.tests,  # for registration initialization
+            ),
+            "contenttype",
+        )
+        root = get_utility(IApplication, name="root")
+
+        configure.load_configuration(root.app.config, "guillotina.tests", "contenttype")
+        root.app.config.execute_actions()
+        load_cached_schema()
+
+        obj = await create_content_in_container(container, "TestType", "foobar")
+
+        constrains = IConstrainTypes(obj, None)
+        assert constrains.get_allowed_types() == ["Item"]
+        assert constrains.is_type_allowed("Item")
+
+        with pytest.raises(NotAllowedContentType):
+            await create_content_in_container(obj, "TestType", "foobar")
+        await create_content_in_container(obj, "Item", "foobar")
 
 
-async def test_allowed_types(dummy_guillotina):
+async def test_creator_used_from_content_creation(db):
     utils.login()
 
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
-    utils.register(container)
+    async with transaction(db=db):
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
+        utils.register(container)
 
-    import guillotina.tests
+        import guillotina.tests
 
-    configure.register_configuration(
-        Folder,
-        dict(
-            type_name="TestType",
-            allowed_types=["Item"],
-            module=guillotina.tests,  # for registration initialization
-        ),
-        "contenttype",
-    )
-    root = get_utility(IApplication, name="root")
+        configure.register_configuration(
+            Folder,
+            dict(
+                type_name="TestType2", behaviors=[], module=guillotina.tests
+            ),  # for registration initialization
+            "contenttype",
+        )
+        root = get_utility(IApplication, name="root")
 
-    configure.load_configuration(root.app.config, "guillotina.tests", "contenttype")
-    root.app.config.execute_actions()
-    load_cached_schema()
+        configure.load_configuration(root.app.config, "guillotina.tests", "contenttype")
+        root.app.config.execute_actions()
+        load_cached_schema()
 
-    obj = await create_content_in_container(container, "TestType", "foobar")
+        obj = await create_content_in_container(
+            container, "TestType2", "foobar", creators=("root",), contributors=("root",)
+        )
 
-    constrains = IConstrainTypes(obj, None)
-    assert constrains.get_allowed_types() == ["Item"]
-    assert constrains.is_type_allowed("Item")
+        assert obj.creators == ("root",)
+        assert obj.contributors == ("root",)
 
-    with pytest.raises(NotAllowedContentType):
-        await create_content_in_container(obj, "TestType", "foobar")
-    await create_content_in_container(obj, "Item", "foobar")
-
-
-async def test_creator_used_from_content_creation(dummy_guillotina):
-    utils.login()
-
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
-    utils.register(container)
-
-    import guillotina.tests
-
-    configure.register_configuration(
-        Folder,
-        dict(type_name="TestType2", behaviors=[], module=guillotina.tests),  # for registration initialization
-        "contenttype",
-    )
-    root = get_utility(IApplication, name="root")
-
-    configure.load_configuration(root.app.config, "guillotina.tests", "contenttype")
-    root.app.config.execute_actions()
-    load_cached_schema()
-
-    obj = await create_content_in_container(
-        container, "TestType2", "foobar", creators=("root",), contributors=("root",)
-    )
-
-    assert obj.creators == ("root",)
-    assert obj.contributors == ("root",)
-
-    behavior = IDublinCore(obj)
-    assert behavior.creators == ("root",)
-    assert behavior.contributors == ("root",)
+        behavior = IDublinCore(obj)
+        assert behavior.creators == ("root",)
+        assert behavior.contributors == ("root",)
 
 
 def test_base_object():
@@ -127,7 +135,6 @@ def test_base_object():
         "__gannotations__": "_BaseObject__annotations",
         "__immutable_cache__": "_BaseObject__immutable_cache",
         "__new_marker__": "_BaseObject__new_marker",
-        "__txn__": "_BaseObject__txn",
         "__uuid__": "_BaseObject__uuid",
         "__serial__": "_BaseObject__serial",
     }

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -17,6 +17,7 @@ from guillotina.test_package import ITestBehavior
 from guillotina.tests import utils
 from guillotina.transactions import transaction
 from guillotina.utils import get_behavior
+from guillotina.utils import get_database
 from guillotina.utils import get_object_by_oid
 
 import json
@@ -34,8 +35,8 @@ class CustomContentType(Item):
     pass
 
 
-async def test_not_allowed_to_create_content(db):
-    async with transaction(db=db):
+async def test_not_allowed_to_create_content(guillotina_main):
+    async with transaction(db=await get_database("db")):
         container = await create_content("Container", id="guillotina", title="Guillotina")
         container.__name__ = "guillotina"
 
@@ -55,10 +56,10 @@ async def test_allowed_to_create_content(db):
         await create_content_in_container(container, "Item", id_="foobar")
 
 
-async def test_allowed_types(db):
+async def test_allowed_types(guillotina_main):
     utils.login()
 
-    async with transaction(db=db):
+    async with transaction(db=await get_database("db")):
         container = await create_content("Container", id="guillotina", title="Guillotina")
         container.__name__ = "guillotina"
         utils.register(container)
@@ -91,10 +92,10 @@ async def test_allowed_types(db):
         await create_content_in_container(obj, "Item", "foobar")
 
 
-async def test_creator_used_from_content_creation(db):
+async def test_creator_used_from_content_creation(guillotina_main):
     utils.login()
 
-    async with transaction(db=db):
+    async with transaction(db=await get_database("db")):
         container = await create_content("Container", id="guillotina", title="Guillotina")
         container.__name__ = "guillotina"
         utils.register(container)

--- a/guillotina/tests/test_dbobjects.py
+++ b/guillotina/tests/test_dbobjects.py
@@ -1,25 +1,19 @@
 from guillotina.behaviors.dublincore import IDublinCore
 from guillotina.content import Item
-from guillotina.db.orm.base import BaseObject
-from guillotina.db.transaction import Transaction
 from guillotina.interfaces import IAnnotations
-from guillotina.interfaces import IResource
-from zope.interface import implementer
+from guillotina.transactions import transaction
+from guillotina.utils import get_database
+from guillotina.content import Item
 
 import pytest
 
 
-@implementer(IResource)
-class ObjectTest(BaseObject):
-    pass
-
-
-async def test_create_object(dummy_txn_root):
-    async with dummy_txn_root as root:
-        assert isinstance(root.__txn__, Transaction)
-        ob1 = ObjectTest()
+async def test_create_object(guillotina_main):
+    async with transaction(db=await get_database("db")) as txn:
+        root = await txn.manager.get_root(txn=txn)
+        ob1 = Item()
+        ob1.type_name = "Item"
         ob1.__new_marker__ = True
-        assert ob1.__txn__ is None
         assert ob1.__serial__ is None
         assert ob1.__uuid__ is None
         assert ob1.__parent__ is None
@@ -29,40 +23,42 @@ async def test_create_object(dummy_txn_root):
         await root.async_set("ob1", ob1)
 
         assert ob1.__name__ == "ob1"
-        assert ob1.__txn__ == root.__txn__
         assert ob1.__uuid__ is not None
         assert ob1.__of__ is None
         assert ob1.__parent__ is root
 
-        assert len(ob1.__txn__.added) == 1
+        assert len(txn.added) == 1
 
 
-async def test_create_annotation(dummy_txn_root):
-    async with dummy_txn_root as root:
-        ob1 = ObjectTest()
+async def test_create_annotation(db):
+    async with transaction(db=await get_database("db")) as txn:
+        root = await txn.manager.get_root(txn=txn)
+        ob1 = Item()
+        ob1.type_name = "Item"
         await root.async_set("ob1", ob1)
         annotations = IAnnotations(ob1)
         with pytest.raises(KeyError):
             await annotations.async_set("test", "hola")
 
-        ob2 = ObjectTest()
+        ob2 = Item()
+        ob2.type_name = "Item"
         assert ob2.__of__ is None
-        assert ob2.__txn__ is None
         assert ob2.__name__ is None
         assert ob2.__parent__ is None
         assert len(ob1.__gannotations__) == 0
 
         await annotations.async_set("test2", ob2)
         assert ob2.__of__ is ob1.__uuid__
-        assert ob2.__txn__ is ob1.__txn__
         assert ob2.__name__ == "test2"
         assert ob2.__parent__ is None
         assert len(ob1.__gannotations__) == 1
 
 
-async def test_use_behavior_annotation(dummy_txn_root):
-    async with dummy_txn_root as root:
+async def test_use_behavior_annotation(db):
+    async with transaction(db=await get_database("db")) as txn:
+        root = await txn.manager.get_root(txn=txn)
         ob1 = Item()
+        ob1.type_name = "Item"
         await root.async_set("ob1", ob1)
         dublin = IDublinCore(ob1)
         await dublin.load()

--- a/guillotina/tests/test_dbobjects.py
+++ b/guillotina/tests/test_dbobjects.py
@@ -3,7 +3,6 @@ from guillotina.content import Item
 from guillotina.interfaces import IAnnotations
 from guillotina.transactions import transaction
 from guillotina.utils import get_database
-from guillotina.content import Item
 
 import pytest
 

--- a/guillotina/tests/test_serialize.py
+++ b/guillotina/tests/test_serialize.py
@@ -23,48 +23,53 @@ import uuid
 
 
 async def test_serialize_resource(dummy_request):
-    content = create_content()
-    serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
-    result = await serializer()
-    assert "guillotina.behaviors.dublincore.IDublinCore" in result
+    with mocks.MockTransaction():
+        content = create_content()
+        serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
+        result = await serializer()
+        assert "guillotina.behaviors.dublincore.IDublinCore" in result
 
 
 async def test_serialize_resource_omit_behavior(dummy_request):
-    content = create_content()
-    serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
-    result = await serializer(omit=["guillotina.behaviors.dublincore.IDublinCore"])
-    assert "guillotina.behaviors.dublincore.IDublinCore" not in result
+    with mocks.MockTransaction():
+        content = create_content()
+        serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
+        result = await serializer(omit=["guillotina.behaviors.dublincore.IDublinCore"])
+        assert "guillotina.behaviors.dublincore.IDublinCore" not in result
 
 
 async def test_serialize_resource_omit_field(dummy_request):
-    content = create_content()
-    serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
-    result = await serializer(omit=["guillotina.behaviors.dublincore.IDublinCore.creators"])
-    assert "creators" not in result["guillotina.behaviors.dublincore.IDublinCore"]
+    with mocks.MockTransaction():
+        content = create_content()
+        serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)
+        result = await serializer(omit=["guillotina.behaviors.dublincore.IDublinCore.creators"])
+        assert "creators" not in result["guillotina.behaviors.dublincore.IDublinCore"]
 
 
 async def test_serialize_resource_include_field(dummy_request):
     from guillotina.test_package import FileContent
 
-    obj = create_content(FileContent, type_name="File")
-    obj.file = DBFile(filename="foobar.json", size=25, md5="foobar")
-    serializer = get_multi_adapter((obj, dummy_request), IResourceSerializeToJson)
-    result = await serializer(include=["guillotina.behaviors.dublincore.IDublinCore.creators"])
-    assert "creators" in result["guillotina.behaviors.dublincore.IDublinCore"]
-    assert len(result["guillotina.behaviors.dublincore.IDublinCore"]) == 1
-    assert "file" not in result
+    with mocks.MockTransaction():
+        obj = create_content(FileContent, type_name="File")
+        obj.file = DBFile(filename="foobar.json", size=25, md5="foobar")
+        serializer = get_multi_adapter((obj, dummy_request), IResourceSerializeToJson)
+        result = await serializer(include=["guillotina.behaviors.dublincore.IDublinCore.creators"])
+        assert "creators" in result["guillotina.behaviors.dublincore.IDublinCore"]
+        assert len(result["guillotina.behaviors.dublincore.IDublinCore"]) == 1
+        assert "file" not in result
 
 
 async def test_serialize_omit_main_interface_field(dummy_request):
     from guillotina.test_package import FileContent
 
-    obj = create_content(FileContent, type_name="File")
-    obj.file = DBFile(filename="foobar.json", size=25, md5="foobar")
-    serializer = get_multi_adapter((obj, dummy_request), IResourceSerializeToJson)
-    result = await serializer(omit=["file"])
-    assert "file" not in result
-    result = await serializer()
-    assert "file" in result
+    with mocks.MockTransaction():
+        obj = create_content(FileContent, type_name="File")
+        obj.file = DBFile(filename="foobar.json", size=25, md5="foobar")
+        serializer = get_multi_adapter((obj, dummy_request), IResourceSerializeToJson)
+        result = await serializer(omit=["file"])
+        assert "file" not in result
+        result = await serializer()
+        assert "file" in result
 
 
 async def test_serialize_cloud_file(dummy_request, dummy_guillotina):
@@ -95,7 +100,7 @@ async def test_serialize_cloud_file(dummy_request, dummy_guillotina):
 async def test_deserialize_cloud_file(dummy_request):
     from guillotina.test_package import IFileContent, FileContent
 
-    with get_tm() as tm, await tm.begin() as txn, dummy_request:
+    with get_tm() as tm, await tm.begin(), dummy_request:
         obj = create_content(FileContent)
         obj.file = None
         await get_adapter(
@@ -207,235 +212,264 @@ async def test_deserialize_dict(dummy_guillotina):
 
 async def test_deserialize_datetime(dummy_guillotina):
     now = datetime.utcnow()
-    converted = schema_compatible(now.isoformat(), ITestSchema["datetime"])
-    assert converted.minute == now.minute
+    with mocks.MockTransaction():
+        converted = schema_compatible(now.isoformat(), ITestSchema["datetime"])
+        assert converted.minute == now.minute
 
 
 async def test_check_permission_deserialize_content(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    assert deserializer.check_permission("guillotina.ViewContent")
-    assert deserializer.check_permission("guillotina.ViewContent")  # with cache
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        assert deserializer.check_permission("guillotina.ViewContent")
+        assert deserializer.check_permission("guillotina.ViewContent")  # with cache
 
 
 async def test_patch_list_field_normal_patch(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(ITestSchema, content, {"patch_list": [{"foo": "bar"}]}, [])
-    assert len(content.patch_list) == 1
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(ITestSchema, content, {"patch_list": [{"foo": "bar"}]}, [])
+        assert len(content.patch_list) == 1
 
 
 async def test_patch_list_field(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_list": {"op": "append", "value": {"foo": "bar"}}}, []
-    )
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_list": {"op": "append", "value": {"foo": "bar"}}}, []
+        )
 
-    assert len(content.patch_list) == 1
-    assert content.patch_list[0] == {"foo": "bar"}
+        assert len(content.patch_list) == 1
+        assert content.patch_list[0] == {"foo": "bar"}
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_list": {"op": "append", "value": {"foo2": "bar2"}}}, []
-    )
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_list": {"op": "append", "value": {"foo2": "bar2"}}}, []
+        )
 
-    assert len(content.patch_list) == 2
-    assert content.patch_list[1] == {"foo2": "bar2"}
+        assert len(content.patch_list) == 2
+        assert content.patch_list[1] == {"foo2": "bar2"}
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {"patch_list": {"op": "extend", "value": [{"foo3": "bar3"}, {"foo4": "bar4"}]}},
-        [],
-    )
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_list": {"op": "extend", "value": [{"foo3": "bar3"}, {"foo4": "bar4"}]}},
+            [],
+        )
 
-    assert len(content.patch_list) == 4
-    assert content.patch_list[-1] == {"foo4": "bar4"}
+        assert len(content.patch_list) == 4
+        assert content.patch_list[-1] == {"foo4": "bar4"}
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {"patch_list": {"op": "update", "value": {"index": 3, "value": {"fooupdated": "barupdated"}}}},
-        [],
-    )
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_list": {"op": "update", "value": {"index": 3, "value": {"fooupdated": "barupdated"}}}},
+            [],
+        )
 
-    assert len(content.patch_list) == 4
-    assert content.patch_list[-1] == {"fooupdated": "barupdated"}
+        assert len(content.patch_list) == 4
+        assert content.patch_list[-1] == {"fooupdated": "barupdated"}
 
-    await deserializer.set_schema(ITestSchema, content, {"patch_list": {"op": "del", "value": 3}}, [])
-    assert len(content.patch_list) == 3
+        await deserializer.set_schema(ITestSchema, content, {"patch_list": {"op": "del", "value": 3}}, [])
+        assert len(content.patch_list) == 3
 
 
 async def test_patch_tuple_field(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(ITestSchema, content, {"patch_tuple": {"op": "append", "value": "foo"}}, [])
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_tuple": {"op": "append", "value": "foo"}}, []
+        )
 
-    assert len(content.patch_tuple) == 1
-    assert content.patch_tuple[0] == "foo"
+        assert len(content.patch_tuple) == 1
+        assert content.patch_tuple[0] == "foo"
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_tuple": {"op": "appendunique", "value": "foo"}}, []
-    )
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_tuple": {"op": "appendunique", "value": "foo"}}, []
+        )
 
-    assert len(content.patch_tuple) == 1
+        assert len(content.patch_tuple) == 1
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_tuple": {"op": "extend", "value": ["bar"]}}, []
-    )
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_tuple": {"op": "extend", "value": ["bar"]}}, []
+        )
 
-    assert len(content.patch_tuple) == 2
-    assert content.patch_tuple[1] == "bar"
+        assert len(content.patch_tuple) == 2
+        assert content.patch_tuple[1] == "bar"
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_tuple": {"op": "extendunique", "value": ["bar"]}}, []
-    )
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_tuple": {"op": "extendunique", "value": ["bar"]}}, []
+        )
 
-    assert len(content.patch_tuple) == 2
+        assert len(content.patch_tuple) == 2
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {"patch_tuple": {"op": "update", "value": {"index": 1, "value": "barupdated"}}},
-        [],
-    )
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_tuple": {"op": "update", "value": {"index": 1, "value": "barupdated"}}},
+            [],
+        )
 
-    assert len(content.patch_tuple) == 2
-    assert content.patch_tuple[1] == "barupdated"
+        assert len(content.patch_tuple) == 2
+        assert content.patch_tuple[1] == "barupdated"
 
-    await deserializer.set_schema(ITestSchema, content, {"patch_tuple": {"op": "del", "value": 1}}, [])
-    assert len(content.patch_tuple) == 1
+        await deserializer.set_schema(ITestSchema, content, {"patch_tuple": {"op": "del", "value": 1}}, [])
+        assert len(content.patch_tuple) == 1
 
 
 async def test_patch_list_field_invalid_type(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    errors = []
-    await deserializer.set_schema(ITestSchema, content, {"patch_list": {"op": "append", "value": 1}}, errors)
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        errors = []
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_list": {"op": "append", "value": 1}}, errors
+        )
 
-    assert len(getattr(content, "patch_list", [])) == 0
-    assert len(errors) == 1
-    assert isinstance(errors[0]["error"], ValueDeserializationError)
+        assert len(getattr(content, "patch_list", [])) == 0
+        assert len(errors) == 1
+        assert isinstance(errors[0]["error"], ValueDeserializationError)
 
 
 async def test_patch_dict_field_normal_patch(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(ITestSchema, content, {"patch_dict": {"foo": "bar"}}, [])
-    assert len(content.patch_dict) == 1
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(ITestSchema, content, {"patch_dict": {"foo": "bar"}}, [])
+        assert len(content.patch_dict) == 1
 
 
 async def test_patch_dict_field(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_dict": {"op": "assign", "value": {"key": "foo", "value": "bar"}}}, []
-    )
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_dict": {"op": "assign", "value": {"key": "foo", "value": "bar"}}},
+            [],
+        )
 
-    assert len(content.patch_dict) == 1
-    assert content.patch_dict["foo"] == "bar"
+        assert len(content.patch_dict) == 1
+        assert content.patch_dict["foo"] == "bar"
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_dict": {"op": "assign", "value": {"key": "foo2", "value": "bar2"}}}, []
-    )
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_dict": {"op": "assign", "value": {"key": "foo2", "value": "bar2"}}},
+            [],
+        )
 
-    assert len(content.patch_dict) == 2
-    assert content.patch_dict["foo2"] == "bar2"
+        assert len(content.patch_dict) == 2
+        assert content.patch_dict["foo2"] == "bar2"
 
-    await deserializer.set_schema(ITestSchema, content, {"patch_dict": {"op": "del", "value": "foo2"}}, [])
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_dict": {"op": "del", "value": "foo2"}}, []
+        )
 
-    assert len(content.patch_dict) == 1
-    assert "foo2" not in content.patch_dict
+        assert len(content.patch_dict) == 1
+        assert "foo2" not in content.patch_dict
 
 
 async def test_patch_dict_field_invalid_type(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    errors = []
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_dict": {"op": "assign", "value": {"key": 1, "value": "bar2"}}}, errors
-    )
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        errors = []
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {"patch_dict": {"op": "assign", "value": {"key": 1, "value": "bar2"}}},
+            errors,
+        )
 
-    assert len(getattr(content, "patch_dict", {})) == 0
-    assert len(errors) == 1
-    assert isinstance(errors[0]["error"], WrongType)
+        assert len(getattr(content, "patch_dict", {})) == 0
+        assert len(errors) == 1
+        assert isinstance(errors[0]["error"], WrongType)
 
 
 async def test_patch_int_field_normal_path(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": 2}, [])
-    assert content.patch_int == 2
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": 2}, [])
+        assert content.patch_int == 2
 
 
 async def test_patch_int_field(dummy_request):
     login()
     content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    # Increment it and check it adds to default value
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "inc", "value": 3}}, [])
-    assert content.patch_int == 25
-    # Check that increments 1 if no value is passed
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "inc"}}, [])
-    assert content.patch_int == 26
+    with mocks.MockTransaction():
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        # Increment it and check it adds to default value
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "inc", "value": 3}}, [])
+        assert content.patch_int == 25
+        # Check that increments 1 if no value is passed
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "inc"}}, [])
+        assert content.patch_int == 26
 
-    # Decrements 1 by default
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec"}}, [])
-    assert content.patch_int == 25
-    # Decrement it
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec", "value": 5}}, [])
-    assert content.patch_int == 20
-    # Check that we can have negative integers
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec", "value": 25}}, [])
-    assert content.patch_int == -5
+        # Decrements 1 by default
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec"}}, [])
+        assert content.patch_int == 25
+        # Decrement it
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec", "value": 5}}, [])
+        assert content.patch_int == 20
+        # Check that we can have negative integers
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "dec", "value": 25}}, [])
+        assert content.patch_int == -5
 
-    # Reset it to default value if not specified
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "reset"}}, [])
-    assert content.patch_int == 22
+        # Reset it to default value if not specified
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "reset"}}, [])
+        assert content.patch_int == 22
 
-    # Reset it to specified value
-    await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "reset", "value": 400}}, [])
-    assert content.patch_int == 400
+        # Reset it to specified value
+        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": "reset", "value": 400}}, [])
+        assert content.patch_int == 400
 
-    # Check that assumes value as 0 if there is no existing value and
-    # no default value either
-    assert getattr(content, "patch_int_no_default", None) is None
-    await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "inc"}}, [])
-    assert content.patch_int_no_default == 1
+        # Check that assumes value as 0 if there is no existing value and
+        # no default value either
+        assert getattr(content, "patch_int_no_default", None) is None
+        await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "inc"}}, [])
+        assert content.patch_int_no_default == 1
 
-    content.patch_int_no_default = None
-    await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "dec"}}, [])
-    assert content.patch_int_no_default == -1
-    content.patch_int_no_default = None
-    await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "reset"}}, [])
-    assert content.patch_int_no_default == 0
+        content.patch_int_no_default = None
+        await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "dec"}}, [])
+        assert content.patch_int_no_default == -1
+        content.patch_int_no_default = None
+        await deserializer.set_schema(ITestSchema, content, {"patch_int_no_default": {"op": "reset"}}, [])
+        assert content.patch_int_no_default == 0
 
 
 async def test_patch_int_field_invalid_type(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    for op in ("inc", "dec", "reset"):
-        errors = []
-        await deserializer.set_schema(ITestSchema, content, {"patch_int": {"op": op, "value": 3.3}}, errors)
-        assert getattr(content, "patch_int", 0) == 0
-        assert len(errors) == 1
-        assert isinstance(errors[0]["error"], WrongType)
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        for op in ("inc", "dec", "reset"):
+            errors = []
+            await deserializer.set_schema(
+                ITestSchema, content, {"patch_int": {"op": op, "value": 3.3}}, errors
+            )
+            assert getattr(content, "patch_int", 0) == 0
+            assert len(errors) == 1
+            assert isinstance(errors[0]["error"], WrongType)
 
 
 async def test_bucket_list_field(db, dummy_request):
     login()
     content = create_content()
-    with mocks.MockTransaction() as txn:
+    with mocks.MockTransaction():
         deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
         await deserializer.set_schema(
             ITestSchema,
@@ -499,76 +533,77 @@ def test_default_value_deserialize(dummy_request):
 
 async def test_nested_patch_deserialize(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    errors = []
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {
-            "nested_patch": {
-                "op": "assign",
-                "value": {
-                    "key": "foobar",
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        errors = []
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {
+                "nested_patch": {
+                    "op": "assign",
                     "value": {
-                        "op": "append",
+                        "key": "foobar",
                         "value": {
-                            "foo": "bar",
-                            "bar": 1,
-                            "foobar_list": None,
-                            "nested_int": {"op": "reset", "value": 5},
+                            "op": "append",
+                            "value": {
+                                "foo": "bar",
+                                "bar": 1,
+                                "foobar_list": None,
+                                "nested_int": {"op": "reset", "value": 5},
+                            },
                         },
                     },
-                },
-            }
-        },
-        errors,
-    )
-    assert len(errors) == 0
-    assert len(content.nested_patch) == 1
-    assert content.nested_patch["foobar"][0]["foo"] == "bar"
-    assert content.nested_patch["foobar"][0]["bar"] == 1
-    assert content.nested_patch["foobar"][0]["nested_int"] == 5
+                }
+            },
+            errors,
+        )
+        assert len(errors) == 0
+        assert len(content.nested_patch) == 1
+        assert content.nested_patch["foobar"][0]["foo"] == "bar"
+        assert content.nested_patch["foobar"][0]["bar"] == 1
+        assert content.nested_patch["foobar"][0]["nested_int"] == 5
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {
-            "nested_patch": {
-                "op": "assign",
-                "value": {"key": "foobar", "value": {"op": "append", "value": {"foo": "bar2", "bar": 2}}},
-            }
-        },
-        errors,
-    )
-    assert len(errors) == 0
-    assert content.nested_patch["foobar"][1]["foo"] == "bar2"
-    assert content.nested_patch["foobar"][1]["bar"] == 2
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {
+                "nested_patch": {
+                    "op": "assign",
+                    "value": {"key": "foobar", "value": {"op": "append", "value": {"foo": "bar2", "bar": 2}}},
+                }
+            },
+            errors,
+        )
+        assert len(errors) == 0
+        assert content.nested_patch["foobar"][1]["foo"] == "bar2"
+        assert content.nested_patch["foobar"][1]["bar"] == 2
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {
-            "nested_patch": {
-                "op": "assign",
-                "value": {
-                    "key": "foobar",
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {
+                "nested_patch": {
+                    "op": "assign",
                     "value": {
-                        "op": "update",
+                        "key": "foobar",
                         "value": {
-                            "index": 1,
-                            "value": {"foo": "bar3", "bar": 3, "nested_int": {"op": "inc"}},
+                            "op": "update",
+                            "value": {
+                                "index": 1,
+                                "value": {"foo": "bar3", "bar": 3, "nested_int": {"op": "inc"}},
+                            },
                         },
                     },
-                },
-            }
-        },
-        errors,
-    )
-    assert len(errors) == 0
-    assert content.nested_patch["foobar"][1]["foo"] == "bar3"
-    assert content.nested_patch["foobar"][1]["bar"] == 3
-    assert content.nested_patch["foobar"][1]["nested_int"] == 1
+                }
+            },
+            errors,
+        )
+        assert len(errors) == 0
+        assert content.nested_patch["foobar"][1]["foo"] == "bar3"
+        assert content.nested_patch["foobar"][1]["bar"] == 3
+        assert content.nested_patch["foobar"][1]["nested_int"] == 1
 
 
 async def test_dates_bucket_list_field(dummy_request):
@@ -599,85 +634,87 @@ async def test_dates_bucket_list_field(dummy_request):
 
 async def test_patchfield_notdefined_field(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    errors = []
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {
-            "dict_of_obj": {
-                "key1": {
-                    "foo": "bar",
-                    "bar": 1,
-                    # Value not found in schema
-                    "not_defined_field": "arbitrary-value",
-                }
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        errors = []
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {
+                "dict_of_obj": {
+                    "key1": {
+                        "foo": "bar",
+                        "bar": 1,
+                        # Value not found in schema
+                        "not_defined_field": "arbitrary-value",
+                    }
+                },
+                "patch_dict_of_obj": {
+                    "key1": {
+                        "foo": "bar",
+                        "bar": 1,
+                        # Value not found in schema
+                        "not_defined_field": "arbitrary-value",
+                    }
+                },
             },
-            "patch_dict_of_obj": {
-                "key1": {
-                    "foo": "bar",
-                    "bar": 1,
-                    # Value not found in schema
-                    "not_defined_field": "arbitrary-value",
-                }
-            },
-        },
-        errors,
-    )
+            errors,
+        )
 
-    assert len(errors) == 0
+        assert len(errors) == 0
 
-    # 'not_defined_field' is not part of INestFieldSchema so should not serialized and stored
-    assert "not_defined_field" not in content.dict_of_obj["key1"]
-    assert "not_defined_field" not in content.patch_dict_of_obj["key1"]
+        # 'not_defined_field' is not part of INestFieldSchema so should not serialized and stored
+        assert "not_defined_field" not in content.dict_of_obj["key1"]
+        assert "not_defined_field" not in content.patch_dict_of_obj["key1"]
 
-    await deserializer.set_schema(
-        ITestSchema,
-        content,
-        {
-            "patch_dict_of_obj": {
-                "op": "assign",
-                "value": {
-                    "key": "key1",
+        await deserializer.set_schema(
+            ITestSchema,
+            content,
+            {
+                "patch_dict_of_obj": {
+                    "op": "assign",
                     "value": {
-                        "op": "append",
+                        "key": "key1",
                         "value": {
-                            "foo": "bar",
-                            "bar": 1,
-                            # Value not found in schema
-                            "not_defined_field": "arbitrary-value",
+                            "op": "append",
+                            "value": {
+                                "foo": "bar",
+                                "bar": 1,
+                                # Value not found in schema
+                                "not_defined_field": "arbitrary-value",
+                            },
                         },
                     },
-                },
-            }
-        },
-        errors,
-    )
+                }
+            },
+            errors,
+        )
 
-    assert len(errors) == 0
-    assert "not_defined_field" not in content.dict_of_obj["key1"]
-    assert "not_defined_field" not in content.patch_dict_of_obj["key1"]
+        assert len(errors) == 0
+        assert "not_defined_field" not in content.dict_of_obj["key1"]
+        assert "not_defined_field" not in content.patch_dict_of_obj["key1"]
 
 
 async def test_delete_by_value_field(dummy_request):
     login()
-    content = create_content()
-    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
-    errors = []
-    await deserializer.set_schema(ITestSchema, content, {"patch_list_int": [1, 2]}, errors)
-    assert errors == []
-    assert getattr(content, "patch_list_int", []) == [1, 2]
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_list_int": {"op": "remove", "value": 2}}, errors
-    )
-    assert errors == []
-    assert getattr(content, "patch_list_int", []) == [1]
+    with mocks.MockTransaction():
+        content = create_content()
+        deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+        errors = []
+        await deserializer.set_schema(ITestSchema, content, {"patch_list_int": [1, 2]}, errors)
+        assert errors == []
+        assert getattr(content, "patch_list_int", []) == [1, 2]
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_list_int": {"op": "remove", "value": 2}}, errors
+        )
+        assert errors == []
+        assert getattr(content, "patch_list_int", []) == [1]
 
-    await deserializer.set_schema(
-        ITestSchema, content, {"patch_list_int": {"op": "remove", "value": 99}}, errors
-    )
-    assert len(errors) == 1
+        await deserializer.set_schema(
+            ITestSchema, content, {"patch_list_int": {"op": "remove", "value": 99}}, errors
+        )
+        assert len(errors) == 1
     assert errors[0]["field"] == "patch_list_int"
 
 

--- a/guillotina/tests/test_transactions.py
+++ b/guillotina/tests/test_transactions.py
@@ -28,7 +28,7 @@ async def test_managed_transaction_with_adoption(container_requester):
             container.title = "changed title"
             container.register()
 
-            assert container.__uuid__ in container.__txn__.modified
+            assert container.__uuid__ in txn.modified
 
             # nest it with adoption
             async with transaction(adopt_parent_txn=True):
@@ -36,7 +36,7 @@ async def test_managed_transaction_with_adoption(container_requester):
                 pass
 
             # no longer modified, adopted in previous txn
-            assert container.__uuid__ not in container.__txn__.modified
+            assert container.__uuid__ not in txn.modified
 
         # finally, retrieve it again and make sure it's updated
         async with transaction(abort_when_done=True):

--- a/guillotina/tests/test_utils.py
+++ b/guillotina/tests/test_utils.py
@@ -1,5 +1,3 @@
-import json
-
 from guillotina import utils
 from guillotina.behaviors.dublincore import IDublinCore
 from guillotina.interfaces import IPrincipalRoleManager
@@ -8,8 +6,12 @@ from guillotina.tests.utils import create_content
 from guillotina.tests.utils import get_mocked_request
 from guillotina.tests.utils import get_root
 from guillotina.tests.utils import login
+from guillotina.transactions import transaction
 from guillotina.utils import get_behavior
+from guillotina.utils import get_database
 from guillotina.utils.navigator import Navigator
+
+import json
 
 
 def test_module_resolve_path():
@@ -73,13 +75,14 @@ def test_valid_id():
     assert not utils.valid_id("FooBar-_-.?")
 
 
-def test_get_owners(dummy_guillotina):
-    content = create_content()
-    roleperm = IPrincipalRoleManager(content)
-    roleperm.assign_role_to_principal("guillotina.Owner", "foobar")
-    assert utils.get_owners(content) == ["foobar"]
-    roleperm.assign_role_to_principal("guillotina.Owner", "foobar2")
-    assert utils.get_owners(content) == ["foobar", "foobar2"]
+async def test_get_owners(dummy_guillotina):
+    async with transaction(db=await get_database("db")):
+        content = create_content()
+        roleperm = IPrincipalRoleManager(content)
+        roleperm.assign_role_to_principal("guillotina.Owner", "foobar")
+        assert utils.get_owners(content) == ["foobar"]
+        roleperm.assign_role_to_principal("guillotina.Owner", "foobar2")
+        assert utils.get_owners(content) == ["foobar", "foobar2"]
 
 
 def test_get_authenticated_user_without_request(dummy_guillotina):

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -1,8 +1,3 @@
-import json
-import uuid
-from contextlib import contextmanager
-from unittest import mock
-
 from aiohttp import hdrs
 from aiohttp import test_utils
 from aiohttp.helpers import noop
@@ -10,6 +5,7 @@ from aiohttp.helpers import sentinel
 from aiohttp.http import HttpVersion
 from aiohttp.http import RawRequestMessage
 from aiohttp.web import UrlMappingMatchInfo
+from contextlib import contextmanager
 from guillotina import task_vars
 from guillotina._settings import app_settings
 from guillotina.auth.users import RootUser
@@ -20,10 +16,15 @@ from guillotina.interfaces import IDefaultLayer
 from guillotina.interfaces import IRequest
 from guillotina.request import Request
 from guillotina.transactions import transaction
+from guillotina.utils import get_current_transaction
 from multidict import CIMultiDict
+from unittest import mock
 from yarl import URL
 from zope.interface import alsoProvides
 from zope.interface import implementer
+
+import json
+import uuid
 
 
 def get_db(app, db_id):
@@ -81,11 +82,8 @@ class FakeRequest(object):
 
 
 def register(ob):
-    if ob.__txn__ is None:
-        from guillotina.tests.mocks import FakeConnection
-
-        conn = FakeConnection()
-        conn.register(ob)
+    txn = get_current_transaction()
+    txn.register(ob)
 
 
 class ContainerRequesterAsyncContextManager:

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -117,7 +117,6 @@ class transaction:  # noqa: N801
     def adopt_objects(self, obs, txn):
         for oid, ob in obs.items():
             self.adopted.append(ob)
-            ob.__txn__ = txn
 
     async def __aexit__(self, exc_type, exc, tb):
         if self.adopt_parent_txn and self.previous_txn is not None:
@@ -150,9 +149,6 @@ class transaction:  # noqa: N801
                 self.previous_txn.modified = {}
                 self.previous_txn.deleted = {}
                 self.previous_txn.added = {}
-
-                for ob in self.adopted:
-                    ob.__txn__ = self.previous_txn
 
         if self.execute_futures:
             from guillotina.utils import execute

--- a/guillotina/utils/__init__.py
+++ b/guillotina/utils/__init__.py
@@ -8,7 +8,6 @@ from .content import get_content_path  # noqa
 from .content import get_database  # noqa
 from .content import get_full_content_path  # noqa
 from .content import get_object_by_uid  # noqa
-from .content import get_object_by_uid as get_object_by_oid  # noqa
 from .content import get_object_url  # noqa
 from .content import get_owners  # noqa
 from .content import iter_databases  # noqa
@@ -17,6 +16,7 @@ from .content import navigate_to  # noqa
 from .content import valid_id  # noqa
 from .crypto import get_jwk_key  # noqa
 from .crypto import secure_passphrase  # noqa
+from .misc import apply_coroutine  # noqa
 from .misc import find_container  # noqa
 from .misc import get_current_container  # noqa
 from .misc import get_current_db  # noqa
@@ -47,4 +47,4 @@ from .modules import resolve_path  # noqa
 from .navigator import Navigator  # noqa
 
 
-from .misc import apply_coroutine  # noqa; noqa
+get_object_by_oid = get_object_by_uid

--- a/guillotina/utils/content.py
+++ b/guillotina/utils/content.py
@@ -102,7 +102,6 @@ async def get_containers():
 
             for _, container in items.items():
                 with await tm.begin() as txn:
-                    container.__txn__ = txn
                     task_vars.container.set(container)
                     yield txn, tm, container
                     try:
@@ -188,7 +187,6 @@ async def get_object_by_uid(uid: str, txn=None) -> IBaseObject:
         raise KeyError(uid)
 
     obj = app_settings["object_reader"](result)
-    obj.__txn__ = txn
     if result["parent_id"]:
         parent = await get_object_by_uid(result["parent_id"], txn)
         if parent is not None:

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -5,7 +5,6 @@ from guillotina import task_vars
 from guillotina._settings import app_settings
 from guillotina.component import get_utility
 from guillotina.db.interfaces import ITransaction
-from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.exceptions import ContainerNotFound
 from guillotina.exceptions import DatabaseNotFound
 from guillotina.exceptions import RequestNotFound

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -5,6 +5,7 @@ from guillotina import task_vars
 from guillotina._settings import app_settings
 from guillotina.component import get_utility
 from guillotina.db.interfaces import ITransaction
+from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.exceptions import ContainerNotFound
 from guillotina.exceptions import DatabaseNotFound
 from guillotina.exceptions import RequestNotFound

--- a/measures/lookups_interfaces.py
+++ b/measures/lookups_interfaces.py
@@ -30,11 +30,9 @@ async def runit(type_name):
     request = get_current_request()
     txn = mocks.MockTransaction()
     container = await create_content(type_name, id="container")
-    container.__txn__ = txn
     start = time.time()
     for _ in range(ITERATIONS):
         ob = await create_content(type_name, id="foobar")
-        ob.__txn__ = txn
         await notify(BeforeObjectAddedEvent(ob, container, "foobar"))
         deserializer = get_multi_adapter((ob, request), IResourceDeserializeFromJson)
         data = {

--- a/measures/serialization.py
+++ b/measures/serialization.py
@@ -23,7 +23,6 @@ async def runit(type_name):
     request = get_current_request()
     txn = mocks.MockTransaction()
     ob = await create_content(type_name, id="foobar")
-    ob.__txn__ = txn
     deserializer = get_multi_adapter((ob, request), IResourceDeserializeFromJson)
     data = {
         "title": "Foobar",


### PR DESCRIPTION
thoughts:

- `__txn__` feels magical
- adding objects to container always means using `parent.__txn__`
- in order to make this work most of the time, you need to have the magic in transaction manager which would reuse txn objects. Otherwise, parents wouldn't be able to add children across transaction boundaries without reassigning `__txn__` all the time. So it added weird cross dependencies
- conceptually, it's much easier to simply to `txn.add(ob)` -- explicit is better than implicit..

implications:
- maybe all object mutate api methods should accept a `txn` argument to be able to customize which txn to register it against(in case you are manually working with multiple transactions).
- I'd also like to find a nice way to auto retry conflict errors when manually working with txn objects. In practice, writing a generic api for this is difficult though.