### PR TITLE
G5 fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.0.0a17 (unreleased)
 ---------------------
 
+- Allow committing objects that were created with different transaction
+  [vangheem]
+
 - Fix async utils to work correctly with transactions and context vars
   [vangheem]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.0.0a17 (unreleased)
 ---------------------
 
+- Fix async utils to work correctly with transactions and context vars
+  [vangheem]
+
 - Be able to have `None` default field values
   [vangheem]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.0.0a17 (unreleased)
 ---------------------
 
+- More normalization of execute module with task_vars/request objects
+  [vangheem]
+
 - Allow committing objects that were created with different transaction
   [vangheem]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.0a17 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Be able to have `None` default field values
+  [vangheem]
 
 
 5.0.0a16 (2019-08-26)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ CHANGELOG
 5.0.0a17 (unreleased)
 ---------------------
 
+- Be able to configure cache to not push pickles with invalidation data
+  [vangheem]
+
+- Fix transaction handling to always get current active transaction, throw exception
+  when transaction is closed and be able to refresh objects.
+  [vangheem]
+
 - More normalization of execute module with task_vars/request objects
   [vangheem]
 

--- a/docs/source/contrib/cache.md
+++ b/docs/source/contrib/cache.md
@@ -19,7 +19,7 @@ applications:
 
 ## In Storage Cache (No invalidations)
 
-This option is not recomended as they are not invalidating the memory objects.
+This option is not recommended as they are not invalidating the memory objects.
 
 Its needed to add `aioredis` as a dependency on your project
 
@@ -30,12 +30,12 @@ applications:
 - guillotina.contrib.redis
 - guillotina.contrib.cache
 cache:
-- driver: guillotina.contrib.redis
+  driver: guillotina.contrib.redis
 ```
 
-## In Storage Cache
+## Redis Storage Cache
 
-This option is the recomended one for more than one process running guillotina on the same DB.
+This option is the recommended one for more than one process running guillotina on the same DB.
 
 Its needed to add `aioredis` as a dependency on your project
 
@@ -47,7 +47,26 @@ applications:
 - guillotina.contrib.pubsub
 - guillotina.contrib.cache
 cache:
-- driver: guillotina.contrib.redis
-- updates_channel: guillotina
+  driver: guillotina.contrib.redis
+  updates_channel: guillotina
 ```
 
+
+### In-memory with redis invalidations
+
+Object invalidations are coordinated across Guillotina instances; however, pushing
+object data into and out of redis can be heavy on redis. Sometimes, an in-memory
+cache configuration but using redis only for pubsub invalidations provides the
+best performance.
+
+```yaml
+applications:
+- guillotina.contrib.redis
+- guillotina.contrib.pubsub
+- guillotina.contrib.cache
+cache:
+  driver:
+  updates_channel: guillotina
+  push: false
+-
+```

--- a/docs/source/migration/5.0.rst
+++ b/docs/source/migration/5.0.rst
@@ -93,3 +93,14 @@ The `ICatalogUtility.query` method is used for "raw" queries coming in. The defa
 use the configured parser and use the `ICatalogUtility.search` with the parsed query.
 
 Individual catalog implementations can decide then override this functionality.
+
+
+Gotchas
+-------
+
+- Context vars do not work in executors!
+- Default field values are now enforced. If you do not define default on fields, you will get AttributeError
+  if the data hasn't been set yet.
+- Beware of TransactionClosedException and TransactionNotFound exceptions. If you do not have a valid
+  transaction setup while you are interacting with objects to write to the database, you will get errors now.
+  This is to prevent you from making mistakes and expecting data to be written when it will not be.

--- a/docs/source/training/extending/events.md
+++ b/docs/source/training/extending/events.md
@@ -20,7 +20,7 @@ from guillotina_chat.content import IConversation
 
 @configure.subscriber(for_=(IConversation, IObjectAddedEvent))
 async def container_added(conversation, event):
-    user_id = get_authenticated_user_id(get_current_request())
+    user_id = get_authenticated_user_id()
     if user_id not in conversation.users:
         conversation.users.append(user_id)
 

--- a/docs/source/training/extending/services.md
+++ b/docs/source/training/extending/services.md
@@ -24,7 +24,7 @@ from guillotina_chat.content import IConversation
 async def get_conversations(context, request):
     results = []
     conversations = await context.async_get('conversations')
-    user_id = get_authenticated_user_id(request)
+    user_id = get_authenticated_user_id()
     async for conversation in conversations.async_values():
         if user_id in getattr(conversation, 'users', []):
             summary = await get_multi_adapter(

--- a/docs/source/training/extending/utilities.md
+++ b/docs/source/training/extending/utilities.md
@@ -105,7 +105,7 @@ from guillotina_chat.utility import IMessageSender
 
 @configure.subscriber(for_=(IConversation, IObjectAddedEvent))
 async def container_added(conversation, event):
-    user_id = get_authenticated_user_id(get_current_request())
+    user_id = get_authenticated_user_id()
     if user_id not in conversation.users:
         conversation.users.append(user_id)
 

--- a/guillotina/annotations.py
+++ b/guillotina/annotations.py
@@ -79,11 +79,11 @@ class AnnotationsAdapter:
         logger.debug("registering annotation {}({}), of: {}".format(value.__uuid__, key, value.__of__))
 
     def _get_transaction(self) -> ITransaction:
-        if self.obj.__txn__ is not None:
-            return self.obj.__txn__
         txn = get_transaction()
         if txn is not None:
             return txn
+        if self.obj.__txn__ is not None:
+            return self.obj.__txn__
         raise TransactionNotFound()
 
     async def async_del(self, key):

--- a/guillotina/annotations.py
+++ b/guillotina/annotations.py
@@ -1,10 +1,13 @@
 from collections import UserDict
 from guillotina import configure
+from guillotina.db.interfaces import ITransaction
 from guillotina.db.orm.base import BaseObject
+from guillotina.exceptions import TransactionNotFound
 from guillotina.interfaces import IAnnotationData
 from guillotina.interfaces import IAnnotations
-from guillotina.interfaces import IResource
 from guillotina.interfaces import IRegistry
+from guillotina.interfaces import IResource
+from guillotina.transactions import get_transaction
 from zope.interface import implementer
 
 import logging
@@ -23,7 +26,7 @@ class AnnotationData(BaseObject, UserDict):
 
 @configure.adapter(for_=IRegistry, provides=IAnnotations)
 @configure.adapter(for_=IResource, provides=IAnnotations)
-class AnnotationsAdapter(object):
+class AnnotationsAdapter:
     """Store annotations on an object
     """
 
@@ -44,9 +47,10 @@ class AnnotationsAdapter(object):
         element = annotations.get(key, _marker)
         if element is _marker:
             # Get from DB
-            if self.obj.__txn__ is not None:
+            txn = self._get_transaction()
+            if txn is not None:
                 try:
-                    obj = await self.obj.__txn__.get_annotation(self.obj, key, reader=reader)
+                    obj = await txn.get_annotation(self.obj, key, reader=reader)
                 except KeyError:
                     obj = None
                 if obj is not None:
@@ -56,7 +60,8 @@ class AnnotationsAdapter(object):
         return default
 
     async def async_keys(self):
-        return await self.obj.__txn__.get_annotation_keys(self.obj.__uuid__)
+        txn = self._get_transaction()
+        return await txn.get_annotation_keys(self.obj.__uuid__)
 
     async def async_set(self, key, value):
         if not isinstance(value, BaseObject):
@@ -68,13 +73,23 @@ class AnnotationsAdapter(object):
         value.__name__ = key
         value.__new_marker__ = True
         # we register the value
-        value.__txn__ = self.obj.__txn__
-        value.__txn__.register(value)
+        txn = self._get_transaction()
+        value.__txn__ = txn
+        txn.register(value)
         logger.debug("registering annotation {}({}), of: {}".format(value.__uuid__, key, value.__of__))
+
+    def _get_transaction(self) -> ITransaction:
+        if self.obj.__txn__ is not None:
+            return self.obj.__txn__
+        txn = get_transaction()
+        if txn is not None:
+            return txn
+        raise TransactionNotFound()
 
     async def async_del(self, key):
         annotation = await self.async_get(key)
         if annotation is not None:
-            self.obj.__txn__.delete(annotation)
+            txn = self._get_transaction()
+            txn.delete(annotation)
             if key in self.obj.__gannotations__:
                 del self.obj.__gannotations__[key]

--- a/guillotina/api/container.py
+++ b/guillotina/api/container.py
@@ -77,6 +77,7 @@ async def create_container(
         await notify(
             ObjectAddedEvent(container, parent, container.__name__, payload={"id": container.id, **data})
         )
+    task_vars.container.set(container)
     return container
 
 

--- a/guillotina/api/service.py
+++ b/guillotina/api/service.py
@@ -37,7 +37,9 @@ class DictFieldProxy:
             return super().__setattr__(name, value)
 
         if name == self.__field_name:
-            getattr(self.__context, name)[self.__key] = value
+            val = getattr(self.__context, name)
+            setattr(self.__context, name, val)
+            val[self.__key] = value
         else:
             setattr(self.__context, name, value)
 

--- a/guillotina/async_util.py
+++ b/guillotina/async_util.py
@@ -1,10 +1,6 @@
-from datetime import datetime
 from dateutil.tz import tzutc
-from guillotina import logger
-from guillotina import task_vars
-from guillotina.browser import View
+from guillotina import logger, task_vars
 from guillotina.db.transaction import Status
-from guillotina.exceptions import RequestNotFound
 from guillotina.exceptions import ServerClosingException
 from guillotina.exceptions import TransactionNotFound
 from guillotina.interfaces import IAsyncJobPool  # noqa
@@ -13,8 +9,9 @@ from guillotina.interfaces import IQueueUtility  # noqa
 from guillotina.transactions import get_tm
 from guillotina.transactions import get_transaction
 from guillotina.transactions import transaction
-from guillotina.utils import find_container
-from guillotina.utils import get_current_request
+from guillotina.utils import dump_task_vars
+from guillotina.utils import execute
+from guillotina.utils import load_task_vars
 
 import asyncio
 import typing
@@ -42,8 +39,11 @@ class QueueUtility(object):
         while True:
             got_obj = False
             try:
-                view, tm, txn = await self.queue.get()
+                func, tvars = await self.queue.get()
                 got_obj = True
+                load_task_vars(tvars)
+                txn = get_transaction()
+                tm = get_tm()
                 if txn is None or (
                     txn.status in (Status.ABORTED, Status.COMMITTED, Status.CONFLICT) and txn._db_conn is None
                 ):
@@ -52,20 +52,16 @@ class QueueUtility(object):
                     # still finishing current transaction, this connection
                     # will be cut off, so we need to wait until we no longer
                     # have an active transaction on the reqeust...
-                    await self.add((view, tm, txn))
+                    await self.add((func, tvars))
                     await asyncio.sleep(1)
                     continue
 
-                container = find_container(view.context)
-                if container is not None:
-                    task_vars.container.set(container)
-                with view.request, tm, txn:
-                    try:
-                        await view()
-                        await tm.commit(txn=txn)
-                    except Exception as e:
-                        logger.error("Exception on writing execution", exc_info=e)
-                        await tm.abort(txn=txn)
+                try:
+                    await func()
+                    await tm.commit(txn=txn)
+                except Exception as e:
+                    logger.error("Exception on writing execution", exc_info=e)
+                    await tm.abort(txn=txn)
             except (
                 RuntimeError,
                 SystemExit,
@@ -81,12 +77,8 @@ class QueueUtility(object):
                 self._exceptions = True
                 logger.error("Worker call failed", exc_info=e)
             finally:
-                task_vars.container.set(None)
                 if got_obj:
-                    try:
-                        view.request.execute_futures()
-                    except AttributeError:
-                        pass
+                    execute.execute_futures()
                     self.queue.task_done()
 
     @property
@@ -98,9 +90,7 @@ class QueueUtility(object):
         return self._total_queued
 
     async def add(self, view):
-        tm = get_tm()
-        txn = get_transaction()
-        await self.queue.put((view, tm, txn))
+        await self.queue.put((view, dump_task_vars()))
         self._total_queued += 1
         return self.queue.qsize()
 
@@ -108,24 +98,12 @@ class QueueUtility(object):
         pass
 
 
-class QueueObject(View):
-    def __init__(self, context, request):
-        # not sure if we need proxy object here...
-        # super(QueueObject, self).__init__(context, TransactionProxy(request))
-        super(QueueObject, self).__init__(context, request)
-        self.time = datetime.now(tz=_zone).timestamp()
-
-    def __lt__(self, view):
-        return self.time < view.time
-
-
 class Job:
     def __init__(
-        self, func: typing.Callable[[], typing.Coroutine], request=None, tm=None, args=None, kwargs=None
+        self, func: typing.Callable[[], typing.Coroutine], _task_vars=None, args=None, kwargs=None
     ) -> None:
         self._func = func
-        self._tm = tm
-        self._request = request
+        self._task_vars = _task_vars
         self._args = args
         self._kwargs = kwargs
 
@@ -134,8 +112,11 @@ class Job:
         return self._func
 
     async def run(self):
-        if self._request is not None:
-            async with self._tm, transaction(tm=self._tm), self._request:
+        if self._task_vars is not None:
+            load_task_vars(self._task_vars)
+        tm = task_vars.tm.get()
+        if tm is not None:
+            async with transaction(tm=tm):
                 await self._func(*self._args or [], **self._kwargs or {})
         else:
             # if no request, we do it without transaction
@@ -170,31 +151,22 @@ class AsyncJobPool:
     async def finalize(self):
         await self.join()
 
-    def add_job(self, func: typing.Callable[[], typing.Coroutine], request=None, args=None, kwargs=None):
+    def add_job(self, func: typing.Callable[[], typing.Coroutine], args=None, kwargs=None):
         if self._closing:
             raise ServerClosingException("Can not schedule job")
-        if request is None:
-            try:
-                request = get_current_request()
-            except RequestNotFound:
-                pass
-        job = Job(func, request=request, tm=get_tm(), args=args, kwargs=kwargs)
+        job = Job(func, _task_vars=dump_task_vars(), args=args, kwargs=kwargs)
         self._pending.insert(0, job)
         self._schedule()
         return job
 
-    def _add_job_after_commit(self, status, func, request=None, args=None, kwargs=None):
-        self.add_job(func, request=request, args=args, kwargs=kwargs)
+    def _add_job_after_commit(self, status, func, args=None, kwargs=None):
+        self.add_job(func, args=args, kwargs=kwargs)
 
-    def add_job_after_commit(
-        self, func: typing.Callable[[], typing.Coroutine], request=None, args=None, kwargs=None
-    ):
+    def add_job_after_commit(self, func: typing.Callable[[], typing.Coroutine], args=None, kwargs=None):
         txn = get_transaction()
         if txn is not None:
             txn.add_after_commit_hook(
-                self._add_job_after_commit,
-                args=[func],
-                kws={"request": request, "args": args, "kwargs": kwargs},
+                self._add_job_after_commit, args=[func], kws={"args": args, "kwargs": kwargs}
             )
         else:
             raise TransactionNotFound("Could not find transaction to run job with")

--- a/guillotina/behaviors/attachment.py
+++ b/guillotina/behaviors/attachment.py
@@ -23,4 +23,4 @@ class IAttachment(Interface):
     title="MultiAttachment behavior", marker=IMultiAttachmentMarker, for_="guillotina.interfaces.IResource"
 )
 class IMultiAttachment(Interface):
-    files = Dict(key_type=TextLine(), value_type=CloudFileField(), missing_value={})
+    files = Dict(key_type=TextLine(), value_type=CloudFileField(), default={}, missing_value={})

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -598,7 +598,10 @@ async def create_content_in_container(
             continue
         setattr(obj, key, value)
 
-    txn = getattr(parent, "__txn__", None) or get_transaction()
+    try:
+        txn = parent._get_transaction()
+    except AttributeError:
+        txn = getattr(parent, "__txn__", None) or get_transaction()
     if txn is None or not txn.storage.supports_unique_constraints:
         # need to manually check unique constraints
         if await parent.async_contains(obj.id):

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -276,11 +276,11 @@ class Folder(Resource):
     """
 
     def _get_transaction(self) -> ITransaction:
-        if self.__txn__ is not None:
-            return self.__txn__
         txn = get_transaction()
         if txn is not None:
             return txn
+        if self.__txn__ is not None:
+            return self.__txn__
         raise TransactionNotFound()
 
     async def async_contains(self, key: str) -> bool:

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -601,7 +601,7 @@ async def create_content_in_container(
     try:
         txn = parent._get_transaction()
     except AttributeError:
-        txn = getattr(parent, "__txn__", None) or get_transaction()
+        txn = getattr(parent, "__txn__", None) or get_transaction()  # type:ignore
     if txn is None or not txn.storage.supports_unique_constraints:
         # need to manually check unique constraints
         if await parent.async_contains(obj.id):

--- a/guillotina/contrib/cache/__init__.py
+++ b/guillotina/contrib/cache/__init__.py
@@ -10,6 +10,7 @@ app_settings = {
         "memory_cache_size": 209715200,
         "strategy": "basic",
         "ttl": 3600,
+        "push": True,  # push out object data to fill other guillotina caches with changes
     },
     "load_utilities": {
         "guillotina_cache": {

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -137,7 +137,6 @@ class BasicCache(BaseCache):
                 keys_to_publish.remove(ob_key)
             push[ob_key] = val
 
-        print(f"Send invalidate {keys_to_publish}")
         self._utility.ignore_tid(self._transaction._tid)
         await self._utility._subscriber.publish(
             app_settings["cache"]["updates_channel"],

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -31,6 +31,10 @@ class BasicCache(BaseCache):
         self._keys_to_publish = []
         self._stored_objects = []
 
+    @property
+    def push_enabled(self):
+        return app_settings["cache"].get("push", True)
+
     @profilable
     async def get(self, **kwargs):
         if self._utility is None:
@@ -71,6 +75,8 @@ class BasicCache(BaseCache):
         await self._utility.delete_all(keys)
 
     async def store_object(self, obj, pickled):
+        if not self.push_enabled:
+            return
         if len(self._stored_objects) < self.max_publish_objects:
             self._stored_objects.append((obj, pickled))
             # also assume these objects are then stored
@@ -102,12 +108,14 @@ class BasicCache(BaseCache):
                 await self.delete_all(keys_to_invalidate)
 
             if len(self._keys_to_publish) > 0 and self._utility._subscriber is not None:
-                asyncio.ensure_future(self.synchronize())
+                keys = self._keys_to_publish
+                asyncio.ensure_future(self.synchronize(keys))
+            self._keys_to_publish = []
         except Exception:
             logger.warning("Error closing connection", exc_info=True)
 
     @profilable
-    async def synchronize(self):
+    async def synchronize(self, keys_to_publish):
         """
         publish cache changes on redis
         """
@@ -125,13 +133,14 @@ class BasicCache(BaseCache):
                 ob_key = self.get_key(container=obj.__parent__, id=obj.__name__)
                 await self.set(val, container=obj.__parent__, id=obj.__name__)
 
-            if ob_key in self._keys_to_publish:
-                self._keys_to_publish.remove(ob_key)
+            if ob_key in keys_to_publish:
+                keys_to_publish.remove(ob_key)
             push[ob_key] = val
 
+        print(f"Send invalidate {keys_to_publish}")
         self._utility.ignore_tid(self._transaction._tid)
         await self._utility._subscriber.publish(
             app_settings["cache"]["updates_channel"],
             self._transaction._tid,
-            {"tid": self._transaction._tid, "keys": self._keys_to_publish, "push": push},
+            {"tid": self._transaction._tid, "keys": keys_to_publish, "push": push},
         )

--- a/guillotina/contrib/cache/utility.py
+++ b/guillotina/contrib/cache/utility.py
@@ -35,7 +35,7 @@ class CacheUtility:
     async def initialize(self, app=None):
         self._memory_cache = memcache.get_memory_cache()
         settings = app_settings["cache"]
-        if settings["driver"] != "":
+        if settings["driver"]:
             klass = resolve_dotted_name(settings["driver"])
             if klass is not None:
                 self._obj_driver = await klass.get_driver()
@@ -153,7 +153,6 @@ class CacheUtility:
                 del self._memory_cache[key]
 
         for cache_key, ob in data.get("push", {}).items():
-            print(f"PUSH {cache_key}")
             self._memory_cache[cache_key] = ob
 
         # clean up possible memory leak

--- a/guillotina/contrib/redis/driver.py
+++ b/guillotina/contrib/redis/driver.py
@@ -44,6 +44,10 @@ class RedisDriver:
         await self._pool.wait_closed()
         self.initialized = False
 
+    @property
+    def pool(self):
+        return self._pool
+
     async def info(self):
         return await self._pool.execute(b"COMMAND", b"INFO", "get")
 

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -8,15 +8,12 @@ import pkg_resources
 from guillotina import app_settings
 from guillotina import configure
 from guillotina.api.service import Service
-from guillotina.component import getMultiAdapter
-from guillotina.interfaces import IAbsoluteURL
 from guillotina.utils import get_authenticated_user
 from guillotina.utils import get_full_content_path
 from guillotina.utils import get_request_scheme
 from guillotina.utils import get_security_policy
-from guillotina.utils import resolve_dotted_name, get_object_url
+from guillotina.utils import resolve_dotted_name
 from zope.interface import Interface
-from zope.interface.interfaces import ComponentLookupError
 
 
 here = os.path.dirname(os.path.realpath(__file__))

--- a/guillotina/db/cache/base.py
+++ b/guillotina/db/cache/base.py
@@ -21,6 +21,7 @@ class BaseCache:
     @_hits.setter
     def _hits(self, value):
         self.__hits += 1
+        self._transaction._manager._cache_hits += 1
 
     @property
     def _misses(self):
@@ -29,6 +30,7 @@ class BaseCache:
     @_misses.setter
     def _misses(self, value):
         self.__misses += 1
+        self._transaction._manager._cache_misses += 1
 
     @property
     def _stored(self):
@@ -37,6 +39,7 @@ class BaseCache:
     @_stored.setter
     def _stored(self, value):
         self.__stored += 1
+        self._transaction._manager._cache_stored += 1
 
     def get_key(self, oid=None, container=None, id=None, variant=None):
         key = "{}-".format(getattr(self._transaction.manager, "db_id", "root"))

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -349,14 +349,8 @@ class Transaction:
                 await result
         self._before_commit = []
 
-    def _validate_object_txn(self, obj):
-        if obj.__txn__ is not self and obj.__txn__ is not None:
-            raise TransactionMismatchException(f"Invalid store reference to txn: {obj}", self, obj)
-
     @profilable
     async def _store_object(self, obj, uid, added=False):
-        self._validate_object_txn(obj)
-
         # There is no serial
         if added:
             serial = None
@@ -380,7 +374,6 @@ class Transaction:
         for oid, obj in self.modified.items():
             await self._store_object(obj, oid)
         for oid, obj in self.deleted.items():
-            self._validate_object_txn(obj)
             await self._manager._storage.delete(self, oid)
 
     @profilable

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -269,6 +269,7 @@ class Transaction:
                 continue
             ob.__dict__[key] = value
         ob.__serial__ = new.__serial__
+        ob.__txn__ = self
 
     @cache(lambda oid: {"oid": oid}, True)
     async def _get(self, oid):

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -72,6 +72,7 @@ class cache:
 class Transaction:
     _status = "empty"
     _skip_commit = False
+    _child_txn = None
 
     def __init__(self, manager, loop=None, read_only=False, validate_objects=True):
         self.initialize(read_only)
@@ -224,7 +225,9 @@ class Transaction:
         if self.read_only:
             raise ReadOnlyError()
 
-        if self.status in (Status.ABORTED, Status.COMMITTED, Status.CONFLICT):
+        if self.status in (Status.ABORTED, Status.COMMITTED, Status.CONFLICT) and (
+            self._child_txn is None or self._child_txn in (Status.ABORTED, Status.COMMITTED, Status.CONFLICT)
+        ):
             raise TransactionClosedException(f"Could not save {obj} to closed transaction", self, obj)
 
         if obj.__txn__ is None:

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -349,10 +349,6 @@ class Transaction:
 
     @profilable
     async def _store_object(self, obj, uid, added=False):
-        # Modified objects
-        if obj.__txn__ is not self and obj.__txn__ is not None:
-            raise Exception(f"Invalid reference to txn: {obj}")
-
         # There is no serial
         if added:
             serial = None
@@ -376,8 +372,6 @@ class Transaction:
         for oid, obj in self.modified.items():
             await self._store_object(obj, oid)
         for oid, obj in self.deleted.items():
-            if obj.__txn__ is not self and obj.__txn__ is not None:
-                raise Exception(f"Invalid reference to txn: {obj}")
             await self._manager._storage.delete(self, oid)
 
     @profilable

--- a/guillotina/db/transaction_manager.py
+++ b/guillotina/db/transaction_manager.py
@@ -37,6 +37,9 @@ class TransactionManager:
         self._db = db
         self._hard_cache = {}
         self._lock = asyncio.Lock()
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cache_stored = 0
 
     @property
     def storage(self):

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -56,6 +56,13 @@ class TransactionClosedException(Exception):
         self.object = ob
 
 
+class TransactionMismatchException(Exception):
+    def __init__(self, msg, txn, ob):
+        super().__init__(msg)
+        self.txn = txn
+        self.object = ob
+
+
 class UnRetryableRequestError(Exception):
     pass
 

--- a/guillotina/factory/content.py
+++ b/guillotina/factory/content.py
@@ -200,6 +200,9 @@ class Database:
             self._tm = self.transaction_klass(self._storage, self)
         return self._tm
 
+    def transaction(self):
+        return self.get_transaction_manager().transaction()
+
     @property
     def __txn__(self) -> typing.Optional[ITransaction]:
         return get_transaction()

--- a/guillotina/json/deserialize_content.py
+++ b/guillotina/json/deserialize_content.py
@@ -81,6 +81,7 @@ class DeserializeFromJson(object):
         write_permissions = merged_tagged_value_dict(schema, write_permission.key)
         changed = False
         for name, field in get_fields(schema).items():
+
             if name in RESERVED_ATTRS:
                 continue
 

--- a/guillotina/schema/utils.py
+++ b/guillotina/schema/utils.py
@@ -31,4 +31,6 @@ def get_default_from_schema(context, schema, fieldname, default=None):
             return deepcopy(field.defaultFactory())
     if field.default is not None:
         return deepcopy(field.default)
+    if field.default != default:
+        return field.default
     return default

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -13,6 +13,7 @@ from guillotina.db.storages.cockroach import CockroachStorage
 from guillotina.factory import make_app
 from guillotina.interfaces import IApplication
 from guillotina.interfaces import IDatabase
+from guillotina.tests import mocks
 from guillotina.tests.utils import ContainerRequesterAsyncContextManager
 from guillotina.tests.utils import get_mocked_request
 from guillotina.tests.utils import login
@@ -301,6 +302,14 @@ class RootAsyncContextManager:
 @pytest.fixture(scope="function")
 async def dummy_txn_root(dummy_request):
     return RootAsyncContextManager(dummy_request)
+
+
+@pytest.fixture(scope="function")
+def mock_txn():
+    txn = mocks.MockTransaction()
+    task_vars.txn.set(txn)
+    yield txn
+    task_vars.txn.set(None)
 
 
 async def _clear_dbs(root):

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -1,11 +1,6 @@
-import asyncio
-import os
-from unittest import mock
-
-import aiohttp
-import pytest
 from aiohttp.client_exceptions import ContentTypeError
 from aiohttp.test_utils import TestServer
+from guillotina import task_vars
 from guillotina import testing
 from guillotina.component import get_utility
 from guillotina.component import globalregistry
@@ -26,6 +21,12 @@ from guillotina.tests.utils import wrap_request
 from guillotina.transactions import get_tm
 from guillotina.transactions import transaction
 from guillotina.utils import merge_dicts
+from unittest import mock
+
+import aiohttp
+import asyncio
+import os
+import pytest
 
 
 _dir = os.path.dirname(os.path.realpath(__file__))
@@ -277,6 +278,7 @@ def dummy_request(dummy_guillotina, monkeypatch):
     db = root["db"]
 
     request = get_mocked_request(db=db)
+    task_vars.request.set(request)
     return request
 
 

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -238,6 +238,19 @@ class GuillotinaDBRequester(object):
 async def close_async_tasks(app):
     for clean in app.on_cleanup:
         await clean(app)
+    # clear all task_vars
+    for var in (
+        "request",
+        "txn",
+        "tm",
+        "futures",
+        "authenticated_user",
+        "security_policies",
+        "container",
+        "registry",
+        "db",
+    ):
+        getattr(task_vars, var).set(None)
 
 
 @pytest.fixture(scope="function")

--- a/guillotina/tests/mocks.py
+++ b/guillotina/tests/mocks.py
@@ -138,6 +138,9 @@ class MockTransactionManager:
             storage = MockStorage()
         self._storage = storage
         self._hard_cache = {}
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cache_stored = 0
 
     async def _close_txn(self, *args, **kwargs):
         pass

--- a/guillotina/tests/redis/test_driver.py
+++ b/guillotina/tests/redis/test_driver.py
@@ -7,6 +7,7 @@ import asyncio
 async def test_redis_ops(redis_container, guillotina_main, loop):
     driver = await resolve_dotted_name("guillotina.contrib.redis").get_driver()
     assert driver.initialized
+    assert driver.pool is not None
 
     await driver.set("test", "testdata", expire=10)
     result = await driver.get("test")

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -43,52 +43,59 @@ def test_indexed_fields(dummy_guillotina, loop):
     assert len(metadata) == 1
 
 
-async def test_get_index_data(dummy_guillotina):
+async def test_get_index_data(dummy_txn_root):
 
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
+    async with dummy_txn_root:
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
 
-    ob = await create_content("Item", id="foobar")
+        ob = await create_content("Item", id="foobar")
 
-    data = ICatalogDataAdapter(ob)
-    fields = await data()
+        data = ICatalogDataAdapter(ob)
+        fields = await data()
 
-    assert "type_name" in fields
-    assert "uuid" in fields
-    assert "path" in fields
-    assert "title" in fields
+        assert "type_name" in fields
+        assert "uuid" in fields
+        assert "path" in fields
+        assert "title" in fields
 
 
-async def test_get_index_data_with_accessors(dummy_request):
-    request = dummy_request  # noqa
+async def test_get_index_data_with_accessors(dummy_txn_root):
+    async with dummy_txn_root:
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
 
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
+        ob = await create_content("Example", id="foobar", categories=[{"label": "foo", "number": 1}])
 
-    ob = await create_content("Example", id="foobar", categories=[{"label": "foo", "number": 1}])
+        data = ICatalogDataAdapter(ob)
+        fields = await data()
+        for field_name in (
+            "categories_accessor",
+            "foobar_accessor",
+            "type_name",
+            "categories",
+            "uuid",
+            "path",
+            "title",
+            "tid",
+        ):
+            assert field_name in fields
 
-    data = ICatalogDataAdapter(ob)
-    fields = await data()
-    for field_name in (
-        "categories_accessor",
-        "foobar_accessor",
-        "type_name",
-        "categories",
-        "uuid",
-        "path",
-        "title",
-        "tid",
-    ):
-        assert field_name in fields
-
-    # now only with indexes specified
-    data = ICatalogDataAdapter(ob)
-    fields = await data(indexes=["categories"])
-    # but should also pull in `foobar_accessor` because it does not
-    # have a field specified for it.
-    for field_name in ("categories_accessor", "foobar_accessor", "type_name", "categories", "uuid", "tid"):
-        assert field_name in fields
-    assert "title" not in fields
+        # now only with indexes specified
+        data = ICatalogDataAdapter(ob)
+        fields = await data(indexes=["categories"])
+        # but should also pull in `foobar_accessor` because it does not
+        # have a field specified for it.
+        for field_name in (
+            "categories_accessor",
+            "foobar_accessor",
+            "type_name",
+            "categories",
+            "uuid",
+            "tid",
+        ):
+            assert field_name in fields
+        assert "title" not in fields
 
 
 async def test_registered_base_utility(dummy_guillotina):
@@ -104,18 +111,19 @@ async def test_get_security_data(dummy_guillotina):
     assert "access_roles" in data
 
 
-async def test_get_data_uses_indexes_param(dummy_guillotina):
-    util = query_utility(ICatalogUtility)
-    container = await create_content("Container", id="guillotina", title="Guillotina")
-    container.__name__ = "guillotina"
-    ob = await create_content("Item", id="foobar")
-    data = await util.get_data(ob, indexes=["title"])
-    assert len(data) == 8  # @uid, type_name, etc always returned
-    data = await util.get_data(ob, indexes=["title", "id"])
-    assert len(data) == 9
+async def test_get_data_uses_indexes_param(dummy_txn_root):
+    async with dummy_txn_root:
+        util = query_utility(ICatalogUtility)
+        container = await create_content("Container", id="guillotina", title="Guillotina")
+        container.__name__ = "guillotina"
+        ob = await create_content("Item", id="foobar")
+        data = await util.get_data(ob, indexes=["title"])
+        assert len(data) == 8  # @uid, type_name, etc always returned
+        data = await util.get_data(ob, indexes=["title", "id"])
+        assert len(data) == 9
 
-    data = await util.get_data(ob)
-    assert len(data) > 10
+        data = await util.get_data(ob)
+        assert len(data) > 10
 
 
 async def test_modified_event_gathers_all_index_data(dummy_guillotina):

--- a/guillotina/tests/test_queue.py
+++ b/guillotina/tests/test_queue.py
@@ -70,7 +70,7 @@ async def test_run_jobs(guillotina):
 
 async def test_run_many_jobs(guillotina, dummy_request):
     pool = get_utility(IAsyncJobPool)
-    jobs = [pool.add_job(JobRunner(), args=["foobar"], request=dummy_request) for _ in range(20)]
+    jobs = [pool.add_job(JobRunner(), args=["foobar"]) for _ in range(20)]
     assert pool.num_running == 5
     assert pool.num_pending == 15
 

--- a/guillotina/tests/test_transactions.py
+++ b/guillotina/tests/test_transactions.py
@@ -1,6 +1,11 @@
+import pytest
+
+from guillotina import task_vars
 from guillotina.content import create_content_in_container
 from guillotina.db import ROOT_ID
 from guillotina.db.transaction import Transaction
+from guillotina.exceptions import TransactionClosedException
+from guillotina.exceptions import TransactionNotFound
 from guillotina.tests import mocks
 from guillotina.transactions import transaction
 from guillotina.utils import get_object_by_uid
@@ -68,3 +73,57 @@ async def test_managed_transaction_works_with_parent_txn_adoption(container_requ
             root = await txn.get(ROOT_ID)
             container = await root.async_get("guillotina")
             assert await container.async_get("foobar") is None
+
+
+async def test_txn_refresh(container_requester):
+    async with container_requester as requester:
+        async with transaction(db=requester.db) as txn:
+            root = await txn.get(ROOT_ID)
+            container1 = await root.async_get("guillotina")
+            container1.title = "changed title"
+            container1.register()
+
+        async with transaction(db=requester.db) as txn:
+            container2 = await root.async_get("guillotina")
+            container2.title = "changed title2"
+            container2.register()
+
+        async with transaction(db=requester.db) as txn:
+            assert container1.__serial__ != container2.__serial__
+            assert container1.title != container2.title
+            await txn.refresh(container1)
+            assert container1.__serial__ == container2.__serial__
+            assert container1.title == container2.title
+
+
+async def test_register_with_local_txn_if_no_global(container_requester):
+    async with container_requester as requester:
+        db = requester.db
+        tm = db.get_transaction_manager()
+        txn = await tm.begin()
+        root = await txn.get(ROOT_ID)
+        container = await root.async_get("guillotina")
+        task_vars.txn.set(None)
+        container.register()
+        assert await container.async_get("foobar") is None
+        assert container.__uuid__ in txn.modified
+        await tm.abort(txn=txn)
+
+        with pytest.raises(TransactionClosedException):
+            # when txn closed, raise exception
+            container.register()
+
+        container.__txn__ = None
+        with pytest.raises(TransactionNotFound):
+            # when no txn found, raise exception
+            container.register()
+
+        with pytest.raises(TransactionNotFound):
+            await container.async_get("foobar")
+
+
+async def test_create_txn_with_db(container_requester):
+    async with container_requester as requester:
+        async with requester.db.transaction() as txn:
+            root = await txn.get(ROOT_ID)
+            assert root is not None

--- a/guillotina/tests/test_transactions.py
+++ b/guillotina/tests/test_transactions.py
@@ -31,7 +31,7 @@ async def test_managed_transaction_with_adoption(container_requester):
             assert container.__uuid__ in container.__txn__.modified
 
             # nest it with adoption
-            async with transaction(adopt_parent_txn=True):
+            async with transaction(db=requester.db, adopt_parent_txn=True):
                 # this should commit, take on parent txn for container
                 pass
 
@@ -39,7 +39,7 @@ async def test_managed_transaction_with_adoption(container_requester):
             assert container.__uuid__ not in container.__txn__.modified
 
         # finally, retrieve it again and make sure it's updated
-        async with transaction(abort_when_done=True):
+        async with transaction(db=requester.db, abort_when_done=True):
             container = await root.async_get("guillotina")
             assert container.title == "changed title"
 

--- a/guillotina/tests/test_utils.py
+++ b/guillotina/tests/test_utils.py
@@ -73,7 +73,7 @@ def test_valid_id():
     assert not utils.valid_id("FooBar-_-.?")
 
 
-def test_get_owners(dummy_guillotina):
+def test_get_owners(dummy_guillotina, mock_txn):
     content = create_content()
     roleperm = IPrincipalRoleManager(content)
     roleperm.assign_role_to_principal("guillotina.Owner", "foobar")

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -34,11 +34,10 @@ def get_db(app, db_id):
 def get_mocked_request(*, db=None, method="POST", path="/", headers=None):
     headers = headers or {}
     request = make_mocked_request(method, path, headers=headers)
-    request._futures = {}
-    request._txn = None
     request.interaction = None
     alsoProvides(request, IRequest)
     alsoProvides(request, IDefaultLayer)
+    task_vars.request.set(request)
     if db is not None:
         db.request = request
         task_vars.db.set(db)

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -112,6 +112,8 @@ class transaction:  # noqa: N801
 
         self.txn = await self.tm.begin(read_only=self.read_only)
         self.txn._validate_objects = self.validate_objects
+        if self.adopt_parent_txn and self.previous_txn is not None:
+            self.previous_txn._child_txn = self.txn
         # these should be restored after
         task_vars.tm.set(self.tm)
         task_vars.txn.set(self.txn)
@@ -156,6 +158,7 @@ class transaction:  # noqa: N801
 
                 for ob in self.adopted:
                     ob.__txn__ = self.previous_txn
+            self.previous_txn._child_txn = None
 
         if self.execute_futures:
             from guillotina.utils import execute

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -92,7 +92,6 @@ class transaction:  # noqa: N801
         adopt_parent_txn=False,
         execute_futures=True,
         read_only=False,
-        validate_objects=True,
     ):
         if db is not None and tm is None:
             tm = db.get_transaction_manager()
@@ -103,7 +102,6 @@ class transaction:  # noqa: N801
         self.execute_futures = execute_futures
         self.adopted = []
         self.read_only = read_only
-        self.validate_objects = validate_objects
 
     async def __aenter__(self):
         txn = get_transaction()
@@ -111,9 +109,6 @@ class transaction:  # noqa: N801
             self.previous_txn = txn
 
         self.txn = await self.tm.begin(read_only=self.read_only)
-        self.txn._validate_objects = self.validate_objects
-        if self.adopt_parent_txn and self.previous_txn is not None:
-            self.previous_txn._child_txn = self.txn
         # these should be restored after
         task_vars.tm.set(self.tm)
         task_vars.txn.set(self.txn)
@@ -158,7 +153,6 @@ class transaction:  # noqa: N801
 
                 for ob in self.adopted:
                     ob.__txn__ = self.previous_txn
-            self.previous_txn._child_txn = None
 
         if self.execute_futures:
             from guillotina.utils import execute

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -117,11 +117,6 @@ class transaction:  # noqa: N801
         task_vars.txn.set(self.txn)
         return self.txn
 
-    def adopt_objects(self, obs, txn):
-        for oid, ob in obs.items():
-            self.adopted.append(ob)
-            ob.__txn__ = txn
-
     async def __aexit__(self, exc_type, exc, tb):
         if self.adopt_parent_txn and self.previous_txn is not None:
             # take on parent's modified, added, deleted objects if necessary
@@ -136,10 +131,6 @@ class transaction:  # noqa: N801
                 self.txn.deleted = {**self.previous_txn.deleted, **self.txn.deleted}
                 self.txn.added = {**self.previous_txn.added, **self.txn.added}
 
-                self.adopt_objects(self.previous_txn.modified, self.txn)
-                self.adopt_objects(self.previous_txn.deleted, self.txn)
-                self.adopt_objects(self.previous_txn.added, self.txn)
-
         if self.abort_when_done:
             await self.tm.abort(txn=self.txn)
         else:
@@ -153,9 +144,6 @@ class transaction:  # noqa: N801
                 self.previous_txn.modified = {}
                 self.previous_txn.deleted = {}
                 self.previous_txn.added = {}
-
-                for ob in self.adopted:
-                    ob.__txn__ = self.previous_txn
 
         if self.execute_futures:
             from guillotina.utils import execute

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -92,6 +92,7 @@ class transaction:  # noqa: N801
         adopt_parent_txn=False,
         execute_futures=True,
         read_only=False,
+        validate_objects=True,
     ):
         if db is not None and tm is None:
             tm = db.get_transaction_manager()
@@ -102,6 +103,7 @@ class transaction:  # noqa: N801
         self.execute_futures = execute_futures
         self.adopted = []
         self.read_only = read_only
+        self.validate_objects
 
     async def __aenter__(self):
         txn = get_transaction()
@@ -109,6 +111,7 @@ class transaction:  # noqa: N801
             self.previous_txn = txn
 
         self.txn = await self.tm.begin(read_only=self.read_only)
+        self.txn._validate_objects = self.validate_objects
         # these should be restored after
         task_vars.tm.set(self.tm)
         task_vars.txn.set(self.txn)

--- a/guillotina/transactions.py
+++ b/guillotina/transactions.py
@@ -103,7 +103,7 @@ class transaction:  # noqa: N801
         self.execute_futures = execute_futures
         self.adopted = []
         self.read_only = read_only
-        self.validate_objects
+        self.validate_objects = validate_objects
 
     async def __aenter__(self):
         txn = get_transaction()

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -187,9 +187,12 @@ class BaseMatchInfo(AbstractMatchInfo):
                 resp.headers["XG-Timing-Total"] = "{0:.5f}".format((last - request._initialized) * 1000)
                 txn = task_vars.txn.get()
                 if txn is not None:
-                    resp.headers["XG-Total-Cache-hits"] = str(txn._cache._hits)
-                    resp.headers["XG-Total-Cache-misses"] = str(txn._cache._misses)
-                    resp.headers["XG-Total-Cache-stored"] = str(txn._cache._stored)
+                    resp.headers["XG-Cache-hits"] = str(txn._cache._hits)
+                    resp.headers["XG-Cache-misses"] = str(txn._cache._misses)
+                    resp.headers["XG-Cache-stored"] = str(txn._cache._stored)
+                    resp.headers["XG-Total-Cache-hits"] = str(txn._manager._cache_hits)
+                    resp.headers["XG-Total-Cache-misses"] = str(txn._manager._cache_misses)
+                    resp.headers["XG-Total-Cache-stored"] = str(txn._manager._cache_stored)
                     resp.headers["XG-Num-Queries"] = str(txn._query_count_end - txn._query_count_start)
                     for idx, query in enumerate(txn._queries.keys()):
                         counts = txn._queries[query]

--- a/guillotina/utils/__init__.py
+++ b/guillotina/utils/__init__.py
@@ -8,7 +8,6 @@ from .content import get_content_path  # noqa
 from .content import get_database  # noqa
 from .content import get_full_content_path  # noqa
 from .content import get_object_by_uid  # noqa
-from .content import get_object_by_uid as get_object_by_oid  # noqa
 from .content import get_object_url  # noqa
 from .content import get_owners  # noqa
 from .content import iter_databases  # noqa
@@ -17,6 +16,7 @@ from .content import navigate_to  # noqa
 from .content import valid_id  # noqa
 from .crypto import get_jwk_key  # noqa
 from .crypto import secure_passphrase  # noqa
+from .misc import dump_task_vars  # noqa
 from .misc import find_container  # noqa
 from .misc import get_current_container  # noqa
 from .misc import get_current_db  # noqa
@@ -29,6 +29,7 @@ from .misc import get_schema_validator  # noqa
 from .misc import get_url  # noqa
 from .misc import lazy_apply  # noqa
 from .misc import list_or_dict_items  # noqa
+from .misc import load_task_vars  # noqa
 from .misc import loop_apply_coroutine  # noqa
 from .misc import merge_dicts  # noqa
 from .misc import notice_on_error  # noqa
@@ -48,3 +49,6 @@ from .navigator import Navigator  # noqa
 
 
 from .misc import apply_coroutine  # noqa; noqa
+
+
+get_object_by_oid = get_object_by_uid

--- a/guillotina/utils/execute.py
+++ b/guillotina/utils/execute.py
@@ -70,7 +70,7 @@ def in_queue(func: Callable[..., Coroutine[Any, Any, Any]], *args, **kwargs) -> 
 in_queue_with_func = in_queue
 
 
-async def __add_to_pool(func: Callable[..., Coroutine[Any, Any, Any]], request, args, kwargs):
+async def __add_to_pool(func: Callable[..., Coroutine[Any, Any, Any]], *args, **kwargs):
     # make add_job async
     util = get_utility(IAsyncJobPool)
     util.add_job(func, args=args, kwargs=kwargs)

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -397,3 +397,14 @@ async def notice_on_error(key: str, func_to_await):
         await func_to_await
     except Exception:  # noqa
         logger.exception(f"Error on initialize utility {key}", exc_info=True)
+
+
+def dump_task_vars(pick=None) -> dict:
+    if pick is None:
+        pick = ("request", "txn", "tm", "futures", "authenticated_user", "container", "registry", "db")
+    return {var: getattr(task_vars, var).get() for var in pick}
+
+
+def load_task_vars(tvars: dict):
+    for k, v in tvars.items():
+        getattr(task_vars, k).set(v)

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -395,6 +395,8 @@ def get_request_scheme(req) -> str:
 async def notice_on_error(key: str, func_to_await):
     try:
         await func_to_await
+    except (asyncio.CancelledError, RuntimeError):
+        pass
     except Exception:  # noqa
         logger.exception(f"Error on initialize utility {key}", exc_info=True)
 


### PR DESCRIPTION
Closing https://github.com/plone/guillotina/pull/650
and instead going to have an ongoing PR for g5 issues

- Be able to configure cache to not push pickles with invalidation data
- Fix transaction handling to always get current active transaction, throw exception when transaction is closed and be able to refresh objects.
- More normalization of execute module with task_vars/request objects
- Allow committing objects that were created with different transaction
- Fix async utils to work correctly with transactions and context vars