### PR TITLE
docs(training): update install docs

### DIFF
--- a/docs/source/training/installation.md
+++ b/docs/source/training/installation.md
@@ -1,13 +1,9 @@
 # Installing Guillotina
 
-Guillotina is a simple Python package so it can be installed with any of the
-number of installation methods available to Python.
+To install Guillotina, we will use [pip](https://pip.pypa.io/en/stable/ "Link to pip's website")
+and [Docker](https://www.docker.com/ "Link to Docker's website").
 
-In the traing here, we will focus on using [pip](https://pip.pypa.io/en/stable/)
-and docker. You can use, for example, buildout as well.
-
-
-## with pip
+Please make sure that you have both installed.
 
 ```eval_rst
 .. note::
@@ -18,23 +14,16 @@ and docker. You can use, for example, buildout as well.
       source ./bin/activate
 ```
 
-
-It's as simple as...
-
-```
+``` shell
 pip install guillotina
 ```
 
+For the purpose of this training, you'll also need to install
+[Cookiecutter](https://cookiecutter.readthedocs.io/en/latest/ "Link to Cookiecutter's website").
 
-For the purpose of this training, you'll also need to install `cookiecutter`.
-
-```
+``` shell
 pip install cookiecutter
 ```
-
-
-Guillotina also provides [docker images](https://hub.docker.com/r/guillotina/guillotina/).
-
 
 **References**
 


### PR DESCRIPTION
# About

This PR improves the installation documentation of the training docs.

# Changes

- Fix typo
- Remove *simple* and *easy*
- Adjust wording
- Remove possible confusing information
- Add syntax highlighting

# Rationale

## Wording

Even if this training is written for developers (I assume :)), there is nothing what is *easy* or *simple* :).
It may so for you, but maybe not for the novice developer who is using Python for the first time.

## Link descriptions

I added link descriptions, that improves the docs in terms of accessibility.

## Links

I added links, maybe not everyone is familiar with Docker, pip, etc

## Typos

Fixed a typo.

## Removed various install instructions.

The whole training is focused on using pip, because of this I removed the mention of the Docker images and buildout.
It is perfect to have that in slides or mention it during training and such.
But in terms of following the training it is less ideal, since the training is for example not using buildout it *just* adds not needed info (which may confuse) to the training.

It is better to focus exactly on the techniques which are used in the training :)

## Syntax highlighting

Add `shell` to code blocks

# Suggestion

Currently, the structure of this document is a bit scattered. I would suggest adding a part on the top of the file mentioning all requirements together and one `pip install` to install `guillotina` and `cookiecutter` with one command :)

Also, maybe a link explaining what a *virtualenv* is?
Maybe the person following the training never used Python before :)


