### PR TITLE
refactor(makefile) add help

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 5.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update Makefile [svx]
 
 
 5.0.2 (2019-08-30)

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,37 @@
+#The shell we use
+SHELL := /bin/bash
+
+# We like colors
+# # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+RESET=`tput sgr0`
+YELLOW=`tput setaf 3`
+
+# Vars
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 
+.PHONY: help
+help: ## This help message
+	@echo -e "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)"
 
-run-postgres:
-	docker run --rm -e POSTGRES_DB=guillotina -e POSTGRES_USER=postgres \
+.PHONY: run-postgres
+run-postgres: ## Run PostgreSQL
+	@echo ""
+	@echo "$(YELLOW)==> Running PostgreSQL $(VERSION)$(RESET)"
+	@docker run --rm -e POSTGRES_DB=guillotina -e POSTGRES_USER=postgres \
 		-p 127.0.0.1:5432:5432 --name postgres postgres:9.6
 
+.PHONY: run-cockroachdb
+run-cockroachdb: ## Run CockroachDB
+	@echo ""
+	@echo "$(YELLOW)==> Running CockroachDB $(VERSION)$(RESET)"
+	@docker run -p 127.0.0.1:26257:26257 -p 127.0.0.1:9080:8080 \
+		--rm cockroachdb/cockroach:v2.0.0 start --insecure
 
-run-cockroachdb:
-	docker pull cockroachdb/cockroach:v2.0.0
-	docker run -p 127.0.0.1:26257:26257 -p 127.0.0.1:9080:8080 --rm cockroachdb/cockroach:v2.0.0 start --insecure
-
-
-create-cockroachdb:
+.PHONY: create-cockroachdb
+create-cockroachdb: ## Create CockroachDB
+	@echo ""
+	@echo "$(YELLOW)==> Creating CockroachDB $(VERSION)$(RESET)"
 	./bin/python _cockroachdb-createdb.py


### PR DESCRIPTION
# About
This PR improves the main `Makefile` by *pinning* the default shell, adding helo, colour and `.Phony` settings

## Rationale

Setting a default shell (`bash`) makes sure that the `Makefile` behaves the same on different systems.
I went with bash, since that one is most commonly installed on systems (macOS, Linux)

Adding color improves the visual.

Adding help, helps you to know what the *make targets* are going to do

Using `.PHONY` is following *good Makefile* standards

:)

![makefile-guillotina](https://user-images.githubusercontent.com/358860/64075620-bee25c80-ccba-11e9-806b-1497d41e37d7.png)
    