### PR TITLE
docs(training): add links to index.rst

### DIFF
--- a/docs/source/training/index.rst
+++ b/docs/source/training/index.rst
@@ -2,9 +2,9 @@ Training
 ========
 
 Prerequisites:
- - Python >= 3.6
- - Docker
- - Postman
+ - `Python 3.7 <https://www.python.org/>`_
+ - `Docker <https://www.docker.com/>`_
+ - `Postman <https://www.getpostman.com/>`_
 
 
 Contents:


### PR DESCRIPTION
# About

This PR adds links to prerequisites which are used/needed.

## Changes

Add links to

- Python
- Docker
- Postman

I also *pinned* the Python version to the same version as is written on other pages.

Using
 ```python
python >=3.6
```
is maybe not understandable for people who are new to Python :)

## Rationale

Maybe not all of these techniques are already known to the trainee or installed.
Adding links helps to *speed up* things, is helpful and friendly.

## Suggestions

Move this file to `md`, with markdown it is possible to use proper link descriptions which is better for accessibility! :)

The prerequisites are also mentioned under *install*, this adds double maintenance, which could lead to mixed or different info, like it is not updated on all places.

The same for the Python version, it would be better to have this only on ONE place, or if you want to stick to Sphinx in the future (I suggest not :) ) Use a *var* in the Sphinx configuration :) 
