### PR TITLE
docs(training): improve running.md

### DIFF
--- a/docs/source/training/running.md
+++ b/docs/source/training/running.md
@@ -1,51 +1,50 @@
 # Starting Guillotina
 
-Once you have [guillotina installed](./installation.html), you can easily run it
+Once you have [guillotina installed](./installation.html "Link to install docs"), you can run it
 with the `g` executable that it installs.
 
-However, before we begin, we'll need to run a postgresql server for Guillotina
-to use.
+Before we begin, you'll need to run a [PostgreSQL](https://www.postgresql.org/ "Link to PostgreSQL's website") server for Guillotina to use.
 
-```
+``` shell
 docker run -e POSTGRES_DB=guillotina -e POSTGRES_USER=postgres -p 127.0.0.1:5432:5432 postgres:9.6
 ```
 
 ```eval_rst
 .. note::
-   This particular docker run command produces a volatile database. Stopping and
-   starting it again will cause you to lose any data you pushed into it.
-```
+   This particular docker run command produces a volatile database.
 
+   Stopping and starting it again will cause you to lose any data you pushed into it.
+```
 
 ## Command
 
-Then, simply run the default Guillotina command `g`.
+Run the default Guillotina command `g`.
 
-```
+``` shell
 g
 ```
 
 Which should give you output like:
 
-```
+``` shell
 $ g
 Could not find the configuration file config.yaml. Using default settings.
 ======== Running on http://0.0.0.0:8080 ========
 (Press CTRL+C to quit)
 ```
 
-The `g` executable allows you to potentially run a number of commands with Guillotina.
-The default command is `serve` if none provided; however, you can explicitly run it with the
+The `g` executable allows you to run a number of commands with Guillotina.
+
+The default command is `serve` if none provided; nevertheless, you can explicitly run it with the
 serve command name as well.
 
 ```
 g serve
 ```
 
-The serve command also takes `--host` and `--port` options to quickly change
-without touching configuration.
+The serve command also takes `--host` and `--port` options to change without touching configuration.
 
-In future sections, we'll explore other commands available.
+In future sections, you'll explore other commands available.
 
 ## Check installation
 
@@ -54,7 +53,7 @@ basic auth credentials for `root` user and `root` password.
 
 Also, do a `GET` on `http://localhost:8080/db`.
 
-Congratulations! You have Guillotina running!
+**Congratulations! You have Guillotina running!**
 
 
 ## Useful run options


### PR DESCRIPTION
# About

This PR improves the training docs about how to run Guillotina for the first time.

# Changes

- Add link
- Adjust wording
- Remove *weasel* words
- Improve consistency by using *you* through the whole document in place from a mix of *you* and *we* 

# Rationale

## Add link

- Add link to https://www.postgresql.org
- Adjust *postgresql* to *PostgreSQL*, since that is the *official* way :)

## Wording

Replace *however* with *nevertheless*, *however* is considered to be less friendly, using *nevertheless* is a bit more supporting and friendly.

## Remove weasel words

Words like *quickly* or *potentially* are not adding a real value, but they could lead to confusion

## Improve consistency

It is always better to address the user clearly :)
The user is following the training, because of that it is better to use *you* consistent through the whole docs :) 

# Suggestion

Rearrange the order and structure to make it a bit *easier* to read through and maybe add some visual, like a picture of a browser screen at the end, when people should have it running and how that would look like :)  