### PR TITLE
Be able to use guillotinas types in 3rd party apps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Be able to use guillotina's types in 3rd party apps
+  [vangheem]
 
 
 5.0.9 (2019-09-05)

--- a/guillotina/constraintypes.py
+++ b/guillotina/constraintypes.py
@@ -3,12 +3,13 @@ from guillotina import configure
 from guillotina.content import get_cached_factory
 from guillotina.interfaces import IConstrainTypes
 from guillotina.interfaces import IDatabase
+from guillotina.interfaces import IResource
 from zope.interface import Interface
 
 
 @configure.adapter(for_=Interface, provides=IConstrainTypes)
 class FTIConstrainAllowedTypes:
-    def __init__(self, context: Interface) -> None:
+    def __init__(self, context: IResource) -> None:
         self.context = context
 
     def is_type_allowed(self, type_id: str) -> bool:
@@ -34,7 +35,7 @@ class DatabaseAllowedTypes:
     Can only add containers to databases
     """
 
-    def __init__(self, context: Interface) -> None:
+    def __init__(self, context: IResource) -> None:
         self.context = context
 
     def is_type_allowed(self, type_id: str) -> bool:

--- a/guillotina/db/interfaces.py
+++ b/guillotina/db/interfaces.py
@@ -120,6 +120,11 @@ class ITransactionManager(Interface):
         abort txn
         """
 
+    async def begin(read_only: bool = False) -> ITransaction:
+        """
+        Begin new transaction
+        """
+
 
 class ITransactionCache(Interface):
     async def clear():  # type: ignore
@@ -287,6 +292,7 @@ class IStorage(Interface):
 class IPostgresStorage(IStorage):
     objects_table_name = Attribute("")
     sql = Attribute("")
+    pool = Attribute("")
 
 
 class ICockroachStorage(IStorage):

--- a/guillotina/db/interfaces.py
+++ b/guillotina/db/interfaces.py
@@ -286,6 +286,7 @@ class IStorage(Interface):
 
 class IPostgresStorage(IStorage):
     objects_table_name = Attribute("")
+    sql = Attribute("")
 
 
 class ICockroachStorage(IStorage):

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -616,6 +616,10 @@ class PostgresqlStorage(BaseStorage):
         await self._connection_manager.close()
 
     @property
+    def sql(self):
+        return self._sql
+
+    @property
     def read_conn(self):
         return self._connection_manager.read_conn
 

--- a/guillotina/interfaces/content.py
+++ b/guillotina/interfaces/content.py
@@ -1,5 +1,6 @@
 from guillotina.component.interfaces import IFactory
 from guillotina.component.interfaces import ISite as IComponentSite
+from guillotina.db.orm.interfaces import IBaseObject
 from guillotina.interfaces.common import IMapping
 from guillotina.schema import TextLine
 from typing import TYPE_CHECKING
@@ -82,7 +83,7 @@ class ITraversable(Interface):
     """
 
 
-class IApplication(ITraversable, IAsyncContainer):
+class IApplication(IBaseObject, ITraversable, IAsyncContainer):
     """
     """
 
@@ -163,7 +164,7 @@ class ILocation(Interface):
     )
 
 
-class IResource(ILocation):
+class IResource(IBaseObject, ILocation):
 
     __acl__ = Attribute("")
     __gannotations__ = Attribute("")

--- a/guillotina/interfaces/types.py
+++ b/guillotina/interfaces/types.py
@@ -1,8 +1,9 @@
+from .content import IResource
 from zope.interface import Interface
 
 
 class IConstrainTypes(Interface):  # pylint: disable=E0239
-    def __init__(context, default=None):  # noqa: N805
+    def __init__(context: IResource, default=None):  # noqa: N805
         """
         """
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     ],
     extras_require={
         "test": [
-            "pytest>=3.8.0",
+            "pytest>=3.8.0<=5.0.0",
             "docker",
             "backoff",
             "psycopg2-binary",

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(
     url="https://github.com/plone/guillotina",
     license="BSD",
     setup_requires=["pytest-runner"],
-    zip_safe=True,
+    zip_safe=False,
     include_package_data=True,
     ext_modules=[lru_module],
-    package_data={"": ["*.txt", "*.rst", "guillotina/documentation/meta/*.json"]},
+    package_data={"": ["*.txt", "*.rst", "guillotina/documentation/meta/*.json"], "guillotina": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
         "aiohttp>=3.0.0,<4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     package_data={"": ["*.txt", "*.rst", "guillotina/documentation/meta/*.json"], "guillotina": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
-        "aiohttp>=3.0.0,<4.0.0",
+        "aiohttp>=3.0.0,<3.6.0",
         "jsonschema",
         "python-dateutil",
         "pycryptodome",


### PR DESCRIPTION
According to, https://mypy.readthedocs.io/en/latest/installed_packages.html#installed-packages you need these stubs in place in order for you to import guillotina to run type checks against.