### PR TITLE
build(sphinx): if possible build in parallel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Adjust Sphinx to build in in parallel
+  [svx]
 
 
 5.0.10 (2019-09-06)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,7 +50,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -j auto -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
# About

This PR adjusts the builder settings for HTML builds with Sphinx.

## Changed Files

- docs/Makefile
- CHANGELOG.rst

# Rationale

By adding `-j auto` to the `make html` target we tell Sphinx to build in parallel where possible.

This speeds up the creation of HTML.

You can find more info in the official Sphinx docs: http://www.sphinx-doc.org/en/master/man/sphinx-build.html.

## Results

Before:

```shell
real	0m6.382s
user	0m6.527s
```

Now:

```shell
real	0m5.741s
user	0m6.559s
```
