### PR TITLE
Fix iter_data mathod for DBFile(file must be DBFile)

### DIFF
--- a/guillotina/files/adapter.py
+++ b/guillotina/files/adapter.py
@@ -168,7 +168,13 @@ class DBFileStorageManagerAdapter:
         await dm.update(_blob=blob)
 
     async def iter_data(self):
-        file = self.field.get(self.field.context or self.context)
+        try:
+            file = self.field.get(self.field.context or self.context)
+        except AttributeError:
+            if isinstance(self.field, DBFile):
+                file = self.field
+            else:
+                raise Exception("Field must be DBFile")
         blob = file._blob
         bfile = blob.open()
         async for chunk in bfile.iter_async_read():

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -289,7 +289,13 @@ class InMemoryFileManager:
 
     async def iter_data(self, uri=None):
         if uri is None:
-            file = self.field.get(self.field.context or self.context)
+            try:
+                file = self.field.get(self.field.context or self.context)
+            except AttributeError:
+                if isinstance(self.field, MemoryFile):
+                    file = self.field
+                else:
+                    raise Exception("Field must be MemoryFile")
             uri = file.uri
         with open(_tmp_files[uri], "rb") as fi:
             chunk = fi.read(1024)


### PR DESCRIPTION
I found that when trying to download DBFiles using FileManager:

`AttributeError: 'DBFile' object has no attribute 'get'`