### PR TITLE
Handle deserialization errors on bucket fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Handle deserialization errors on bucket fields. Otherwise, dict values were getting incorrectly saved
+  [vangheem]
 
 
 5.0.15 (2019-10-02)

--- a/guillotina/tests/test_serialize.py
+++ b/guillotina/tests/test_serialize.py
@@ -16,7 +16,6 @@ from guillotina.tests.utils import create_content
 from guillotina.tests.utils import login
 from zope.interface import Interface
 
-import pytest
 import uuid
 
 

--- a/guillotina/tests/test_serialize.py
+++ b/guillotina/tests/test_serialize.py
@@ -16,6 +16,7 @@ from guillotina.tests.utils import create_content
 from guillotina.tests.utils import login
 from zope.interface import Interface
 
+import pytest
 import uuid
 
 
@@ -734,3 +735,15 @@ async def test_bucket_dict_field(dummy_request, mock_txn):
     # check all values as well
     for idx, key in enumerate(all_keys):
         assert inserted[key] == all_values[idx]
+
+
+async def test_unhandled_exceptions_in_bucket_dict_field_do_not_write_to_object(dummy_request, mock_txn):
+    login()
+    content = create_content()
+    deserializer = get_multi_adapter((content, dummy_request), IResourceDeserializeFromJson)
+    errors = []
+    await deserializer.set_schema(
+        ITestSchema, content, {"bucket_dict": {"op": "assign", "value": None}}, errors
+    )
+    assert not hasattr(content, "bucket_dict")
+    assert len(errors) == 1


### PR DESCRIPTION
Otherwise, dict value…s were getting incorrectly saved