### PR TITLE
Fix push invalidation data type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix push invalidation data type
+  [vangheem]
 
 
 5.0.21 (2019-10-16)

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -125,7 +125,7 @@ class BasicCache(BaseCache):
             raise NoPubSubUtility()
         if app_settings.get("cache", {}).get("updates_channel", None) is None:
             raise NoChannelConfigured()
-        push = []
+        push = {}
         for obj, pickled in self._stored_objects:
             val = {
                 "state": pickled,

--- a/guillotina/contrib/cache/utility.py
+++ b/guillotina/contrib/cache/utility.py
@@ -160,8 +160,10 @@ class CacheUtility:
             if key in self._memory_cache:
                 del self._memory_cache[key]
 
-        for cache_key, ob in data.get("push", {}).items():
-            self._memory_cache.set(cache_key, ob, self.get_size(ob))
+        push = data.get("push", {})
+        if isinstance(push, dict):
+            for cache_key, ob in push.items():
+                self._memory_cache.set(cache_key, ob, self.get_size(ob))
 
         # clean up possible memory leak
         while len(self._ignored_tids) > 100:


### PR DESCRIPTION
@bloodbare I don't think we have any tests in this part of our cache invalidation...

I don't use this but @masipcat said this happened with latest release.