### PR TITLE
fix error closing the cache on some objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.0.24 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix error closing cache with some objects
+  [vangheem]
 
 
 5.0.23 (2019-10-17)

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -145,8 +145,11 @@ class BasicCache(BaseCache):
                     val, [dict(oid=obj.__of__, id=obj.__name__, variant="annotation"), dict(oid=obj.__uuid__)]
                 )
             else:
-                val["parent_id"] = obj.__parent__.__uuid__
-                await self.set(val, [dict(container=obj.__parent__, id=obj.__name__), dict(oid=obj.__uuid__)])
+                keyset = [dict(oid=obj.__uuid__)]
+                if obj.__parent__:
+                    val["parent_id"] = obj.__parent__.__uuid__
+                    keyset.append(dict(container=obj.__parent__, id=obj.__name__))
+                await self.set(val, keyset)
 
     @profilable
     async def synchronize(self, keys_to_publish):
@@ -164,7 +167,10 @@ class BasicCache(BaseCache):
                 if obj.__of__:
                     ob_key = self.get_key(oid=obj.__of__, id=obj.__name__, variant="annotation")
                 else:
-                    ob_key = self.get_key(container=obj.__parent__, id=obj.__name__)
+                    if obj.__parent__:
+                        ob_key = self.get_key(container=obj.__parent__, id=obj.__name__)
+                    else:
+                        ob_key = self.get_key(oid=obj.__uuid__)
                 push[ob_key] = val
 
         self._stored_objects.clear()


### PR DESCRIPTION
This also exposed an error with this implementation because we were doing `self.get_key(container=obj.__parent__, id=obj.__name__)` when `obj.__parent__` was `None`. So we were setting invalid cache values.

```
WARNING:guillotina:Error closing connection
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/guillotina/contrib/cache/strategy.py", line 125, in close
    await self.fill_cache()
  File "/usr/local/lib/python3.7/site-packages/guillotina/contrib/cache/strategy.py", line 148, in fill_cache
    val["parent_id"] = obj.__parent__.__uuid__
AttributeError: 'NoneType' object has no attribute '__uuid__'
```