### PR TITLE
be able to customize number of workers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.1.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Be able to customize number of thread pool workers
+  [vangheem]
 
 
 5.1.9 (2019-11-12)

--- a/guillotina/_settings.py
+++ b/guillotina/_settings.py
@@ -91,5 +91,6 @@ app_settings: Dict[str, Any] = {
     "indexer": "guillotina.catalog.index.Indexer",
     "search_parser": "default",
     "object_reader": "guillotina.db.reader.reader",
+    "thread_pool_workers": 32,
 }
 default_settings = copy.deepcopy(app_settings)

--- a/guillotina/factory/content.py
+++ b/guillotina/factory/content.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("guillotina")
 
 @implementer(IApplication)
 class ApplicationRoot:  # type: ignore
-    executor = ThreadPoolExecutor(max_workers=100)
+    executor = ThreadPoolExecutor(max_workers=app_settings.get("thread_pool_workers", 32))
     root_user = None
     app = None  # set after app configuration is done
 


### PR DESCRIPTION
100 seems quite large and the max recommended in docs is 32. Any reason we should leave this at 100?