### PR TITLE
Remove task call back to run execute_futures automatically

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 5.1.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove task call back to run execute_futures automatically. aiohttp reuses task object for
+  keepalive implementation and the `_callbacks` were never run
+  [vangheem]
 
 
 5.1.11 (2019-11-12)

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -258,7 +258,7 @@ def _clean_request(request, response):
             traceback.clear_frames(response.__traceback__)
         if response.exc is not None:
             traceback.clear_frames(response.exc.__traceback__)
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         pass
 
     for attr in ("resource", "found_view", "exc"):

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -253,10 +253,15 @@ async def _apply_cors(request, resp):
 
 
 def _clean_request(request, response):
-    if isinstance(response, Exception):
-        traceback.clear_frames(response.__traceback__)
+    try:
+        if isinstance(response, Exception):
+            traceback.clear_frames(response.__traceback__)
+        if response.exc is not None:
+            traceback.clear_frames(response.exc.__traceback__)
+    except AttributeError:
+        pass
 
-    for attr in ("resource", "found_view"):
+    for attr in ("resource", "found_view", "exc"):
         if getattr(request, attr, None) is not None:
             setattr(request, attr, None)
 

--- a/guillotina/utils/execute.py
+++ b/guillotina/utils/execute.py
@@ -164,9 +164,6 @@ def add_future(
     if futures is None:
         futures = {}
         task_vars.futures.set(futures)
-        task = asyncio.current_task()
-        if task is not None and scope == "":
-            task.add_done_callback(partial(execute_futures, scope, futures))
     if scope not in futures:
         futures[scope] = {}
     futures[scope][name] = {"fut": fut, "args": args, "kwargs": kwargs}


### PR DESCRIPTION
aiohttp reuses task object for keepalive implementation and the `_callbacks` were never run