### PR TITLE
Fix security bug on duplicate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,7 @@ CHANGELOG
 5.1.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix security bug in @move and @duplicate [lferran]
 
 5.1.21 (2019-11-29)
 -------------------

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -576,7 +576,9 @@ async def move(context, request):
         data = {}
 
     try:
-        await content.move(context, **data)
+        await content.move(
+            context, destination=data.get("destination"), new_id=data.get("new_id"), check_permission=True
+        )
     except TypeError:
         raise ErrorResponse(
             "RequiredParam", _("Invalid params"), reason=error_reasons.REQUIRED_PARAM_MISSING, status=412

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -621,7 +621,7 @@ async def duplicate(context, request):
         data = {}
 
     try:
-        new_obj = await content.duplicate(context, **data)
+        new_obj = await content.duplicate(context, **data, check_permission=True)
     except TypeError:
         raise ErrorResponse(
             "RequiredParam", _("Invalid params"), reason=error_reasons.REQUIRED_PARAM_MISSING, status=412

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -619,10 +619,11 @@ async def duplicate(context, request):
         data = await request.json()
     except Exception:
         data = {}
-
     try:
-        new_obj = await content.duplicate(context, **data, check_permission=True)
-    except TypeError:
+        new_obj = await content.duplicate(
+            context, destination=data.get("destination"), new_id=data.get("new_id"), check_permission=True
+        )
+    except TypeError as err:
         raise ErrorResponse(
             "RequiredParam", _("Invalid params"), reason=error_reasons.REQUIRED_PARAM_MISSING, status=412
         )

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -623,7 +623,7 @@ async def duplicate(context, request):
         new_obj = await content.duplicate(
             context, destination=data.get("destination"), new_id=data.get("new_id"), check_permission=True
         )
-    except TypeError as err:
+    except TypeError:
         raise ErrorResponse(
             "RequiredParam", _("Invalid params"), reason=error_reasons.REQUIRED_PARAM_MISSING, status=412
         )

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -700,6 +700,7 @@ async def duplicate(
         id=new_id,
         creators=context.creators,
         contributors=context.contributors,
+        check_security=check_permission,
     )
 
     for key in context.__dict__.keys():

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -647,8 +647,8 @@ async def get_all_behaviors(content, create=False, load=True) -> list:
 
 async def duplicate(
     context: IResource,
-    destination: Union[IResource, str] = None,
-    new_id: str = None,
+    destination: Optional[Union[IResource, str]] = None,
+    new_id: Optional[str] = None,
     check_permission: bool = True,
 ) -> IResource:
     if destination is not None:

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -733,8 +733,8 @@ async def duplicate(
 
 async def move(
     context: IResource,
-    destination: Union[IResource, str] = None,
-    new_id: str = None,
+    destination: Optional[Union[IResource, str]] = None,
+    new_id: Optional[str] = None,
     check_permission: bool = True,
 ) -> None:
     if destination is None:

--- a/guillotina/contrib/dbusers/services/users.py
+++ b/guillotina/contrib/dbusers/services/users.py
@@ -21,6 +21,7 @@ import typing
 @configure.service(
     context=IContainer,
     name="@user_info",
+    permission="guillotina.AccessContent",
     method="GET",
     summary="Get info about authenticated user",
     allow_access=True,

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -615,7 +615,7 @@ async def test_duplicate_content(container_requester):
 
 
 @pytest.mark.app_settings(DBUSERS_DEFAULT_SETTINGS)
-async def test_duplicate_content_allways_checks_permission_on_destination(dbusers_requester):
+async def test_duplicate_content_always_checks_permission_on_destination(dbusers_requester):
     async with dbusers_requester as requester:
         # Add Bob user
         _, status = await requester(
@@ -686,7 +686,7 @@ async def test_duplicate_content_allways_checks_permission_on_destination(dbuser
         )
 
         # Alice tries to duplicate the file into Bob's folder
-        _, status = await requester(
+        resp, status = await requester(
             "POST",
             "/db/guillotina/users/bob/foobar1/@duplicate",
             data=json.dumps(
@@ -700,6 +700,7 @@ async def test_duplicate_content_allways_checks_permission_on_destination(dbuser
             token=alice_token,
         )
         assert status == 412
+        assert "You do not have permission to add content to the destination object" in resp["message"]
 
 
 async def test_create_content_fields(container_requester):

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from guillotina import configure
 from guillotina import schema
 from guillotina.addons import Addon
-from guillotina.auth.users import GuillotinaUser
 from guillotina.behaviors.attachment import IAttachment
 from guillotina.behaviors.dublincore import IDublinCore
 from guillotina.interfaces import IAnnotations

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -655,19 +655,20 @@ async def test_duplicate_content_allways_checks_permission_on_destination(dbuser
         bob_token = base64.b64encode(b"bob:bob").decode("ascii")
         alice_token = base64.b64encode(b"alice:alice").decode("ascii")
 
-        # Bob creates a file
-        await requester(
+        # Bob creates a file in its folder
+        _, status = await requester(
             "POST",
-            "/db/guillotina/",
+            "/db/guillotina/users/bob/",
             data=json.dumps({"@type": "Item", "id": "foobar1"}),
             auth_type="Basic",
             token=bob_token,
         )
+        assert status in (200, 201)
 
         # Shares it with alice as manager
         _, status = await requester(
             "POST",
-            "/db/guillotina/foobar1/@sharing",
+            "/db/guillotina/users/bob/foobar1/@sharing",
             data=json.dumps(
                 {"prinrole": [{"principal": "alice", "role": "guillotina.Owner", "setting": "Allow"}]}
             ),
@@ -679,7 +680,7 @@ async def test_duplicate_content_allways_checks_permission_on_destination(dbuser
         # Bob creates a folder
         await requester(
             "POST",
-            "/db/guillotina/",
+            "/db/guillotina/users/bob/",
             data=json.dumps({"@type": "Folder", "id": "bobfolder"}),
             auth_type="Basic",
             token=bob_token,
@@ -688,9 +689,13 @@ async def test_duplicate_content_allways_checks_permission_on_destination(dbuser
         # Alice tries to duplicate the file into Bob's folder
         _, status = await requester(
             "POST",
-            "/db/guillotina/foobar1",
+            "/db/guillotina/users/bob/foobar1/@duplicate",
             data=json.dumps(
-                {"new_id": "foobar-from-alice", "destination": "/bobfolder", "check_permission": False}
+                {
+                    "new_id": "foobar-from-alice",
+                    "destination": "/users/bob/bobfolder",
+                    "check_permission": False,
+                }
             ),
             auth_type="Basic",
             token=alice_token,


### PR DESCRIPTION
By setting `check_permission: False` on the payload, caller was able to create content on destination even if he/she didn't have access to.