### PR TITLE
Provide an endpoint to list global roles.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ CHANGELOG
   [masipcat]
 - Added uvicorn as a guillotina requirement
   [masipcat]
+- Added endpoint @available-roles on container
 
 
 6.0.0a1 (2019-12-09)

--- a/guillotina/contrib/dbusers/services/__init__.py
+++ b/guillotina/contrib/dbusers/services/__init__.py
@@ -1,5 +1,6 @@
 from . import groups  # noqa
 from . import users  # noqa
+from . import roles  # noqa
 from guillotina import configure
 from guillotina.api.content import DefaultPOST
 from guillotina.contrib.dbusers.content.groups import IGroupManager

--- a/guillotina/contrib/dbusers/services/roles.py
+++ b/guillotina/contrib/dbusers/services/roles.py
@@ -1,0 +1,17 @@
+from guillotina import configure
+from guillotina.api.service import Service
+from guillotina.auth.role import global_roles
+from guillotina.interfaces import IContainer
+
+
+@configure.service(
+    context=IContainer,
+    name="@available-roles",
+    permission="guillotina.ManageUsers",
+    summary="Get available roles on guillotina container",
+    method="GET"
+)
+class AvailableRoles(Service):
+    async def __call__(self):
+        roles = global_roles()
+        return roles


### PR DESCRIPTION
With this, from the api, a user with permissions to manage users,
can assign global roles to users and groups