### PR TITLE
Replace pytest-asyncio with alt-pytest-asyncio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.0a4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Replace pytest-asyncio with alt-pytest-asyncio
+  [masipcat]
 
 
 6.0.0a3 (2019-12-18)

--- a/guillotina/commands/__init__.py
+++ b/guillotina/commands/__init__.py
@@ -17,13 +17,6 @@ import yaml
 
 
 try:
-    import uvloop  # type: ignore
-
-    uvloop.install()
-except ImportError:
-    pass
-
-try:
     import line_profiler  # type: ignore
 
     HAS_LINE_PROFILER = True

--- a/guillotina/tests/cache/test_cache_memory.py
+++ b/guillotina/tests/cache/test_cache_memory.py
@@ -8,9 +8,6 @@ from guillotina.tests.utils import create_content
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 DEFAULT_SETTINGS = {
     "applications": ["guillotina", "guillotina.contrib.cache"],
     "cache": {"updates_channel": None, "driver": None},

--- a/guillotina/tests/cache/test_cache_pubsub.py
+++ b/guillotina/tests/cache/test_cache_pubsub.py
@@ -13,9 +13,6 @@ import pickle
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 DEFAULT_SETTINGS = {
     "applications": [
         "guillotina",

--- a/guillotina/tests/cache/test_cache_store.py
+++ b/guillotina/tests/cache/test_cache_store.py
@@ -9,8 +9,6 @@ from guillotina.utils import resolve_dotted_name
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
 DEFAULT_SETTINGS = {
     "applications": ["guillotina", "guillotina.contrib.redis", "guillotina.contrib.cache"],
     "cache": {"updates_channel": None, "driver": "guillotina.contrib.redis"},

--- a/guillotina/tests/cache/test_cache_txn.py
+++ b/guillotina/tests/cache/test_cache_txn.py
@@ -10,9 +10,6 @@ from guillotina.utils import get_database
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 DEFAULT_SETTINGS = {
     "applications": ["guillotina", "guillotina.contrib.redis", "guillotina.contrib.cache"],
     "cache": {"updates_channel": None, "driver": "guillotina.contrib.redis"},

--- a/guillotina/tests/cache/test_utils.py
+++ b/guillotina/tests/cache/test_utils.py
@@ -1,9 +1,6 @@
 from guillotina.contrib.cache.utility import CacheUtility
 
-import pytest
 
-
-@pytest.mark.asyncio
 async def test_get_size_of_item():
     rcache = CacheUtility()
     from guillotina.contrib.cache.utility import _default_size

--- a/guillotina/tests/dbusers/test_api.py
+++ b/guillotina/tests/dbusers/test_api.py
@@ -7,9 +7,6 @@ import pytest
 import random
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @pytest.mark.app_settings(settings.DEFAULT_SETTINGS)
 async def test_add_user(dbusers_requester):
     async with dbusers_requester as requester:

--- a/guillotina/tests/dbusers/test_manage_groups.py
+++ b/guillotina/tests/dbusers/test_manage_groups.py
@@ -6,9 +6,6 @@ import json
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 _group = {"name": "foo", "description": "foo description", "@type": "Group", "id": "foo"}
 
 

--- a/guillotina/tests/dbusers/test_manage_users.py
+++ b/guillotina/tests/dbusers/test_manage_users.py
@@ -6,9 +6,6 @@ import json
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @pytest.fixture()
 async def user_data():
     return settings.user_data

--- a/guillotina/tests/dbusers/test_setup.py
+++ b/guillotina/tests/dbusers/test_setup.py
@@ -4,9 +4,6 @@ from guillotina.tests.utils import get_container
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @pytest.mark.app_settings(settings.DEFAULT_SETTINGS)
 async def test_users_and_groups_folders_are_created_on_install(dbusers_requester):
     async with dbusers_requester as requester:

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -48,21 +48,6 @@ def base_settings_configurator(settings):
 testing.configure_with(base_settings_configurator)
 
 
-@pytest.yield_fixture
-def event_loop():
-    """Create an instance of the default event loop for each test case."""
-    # https://github.com/pytest-dev/pytest-asyncio/issues/30#issuecomment-226947196
-    policy = asyncio.get_event_loop_policy()
-    res = policy.new_event_loop()
-    asyncio.set_event_loop(res)
-    res._close = res.close
-    res.close = lambda: None
-
-    yield res
-
-    res._close()
-
-
 def get_dummy_settings(pytest_node=None):
     settings = testing.get_settings()
     settings = _update_from_pytest_markers(settings, pytest_node)

--- a/guillotina/tests/mailer/test_mailer.py
+++ b/guillotina/tests/mailer/test_mailer.py
@@ -4,9 +4,6 @@ from guillotina.interfaces import IMailer
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @pytest.mark.app_settings(
     {
         "applications": ["guillotina", "guillotina.contrib.mailer"],

--- a/guillotina/tests/pubsub/test_pubsub.py
+++ b/guillotina/tests/pubsub/test_pubsub.py
@@ -8,7 +8,6 @@ import pytest
 @pytest.mark.app_settings(
     {"applications": ["guillotina", "guillotina.contrib.redis", "guillotina.contrib.pubsub"]}
 )
-@pytest.mark.asyncio
 async def test_pubsub(redis_container, guillotina_main):
     util = get_utility(IPubSubUtility)
     await util.initialize()

--- a/guillotina/tests/redis/test_driver.py
+++ b/guillotina/tests/redis/test_driver.py
@@ -4,9 +4,6 @@ import asyncio
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @pytest.mark.app_settings({"applications": ["guillotina", "guillotina.contrib.redis"]})
 async def test_redis_ops(redis_container, guillotina_main):
     driver = await resolve_dotted_name("guillotina.contrib.redis").get_driver()

--- a/guillotina/tests/test_adapters.py
+++ b/guillotina/tests/test_adapters.py
@@ -25,30 +25,24 @@ from guillotina.json.serialize_content import SerializeFolderToJson
 from guillotina.json.serialize_content import SerializeToJson
 from guillotina.json.serialize_value import json_compatible
 
-import pytest
 
-
-@pytest.mark.asyncio
 async def test_DatabaseSpecialPermissions_IDatabase(dummy_txn_root):  # noqa: N802
     async with dummy_txn_root as root:
         adapter = get_adapter(root, interface=IPrincipalPermissionManager)
         assert isinstance(adapter, DatabaseSpecialPermissions)
 
 
-@pytest.mark.asyncio
 async def test_RootSpecialPermissions_IApplication(dummy_guillotina):  # noqa: N802
     root = get_utility(IApplication, name="root")
     adapter = get_adapter(root, interface=IPrincipalPermissionManager)
     assert isinstance(adapter, ApplicationSpecialPermissions)
 
 
-@pytest.mark.asyncio
 async def test_SerializeFolderToJson(dummy_request):  # noqa: N802
     adapter = get_multi_adapter((Container(), dummy_request), interface=IResourceSerializeToJson)
     assert isinstance(adapter, SerializeFolderToJson)
 
 
-@pytest.mark.asyncio
 async def test_SerializeToJson(dummy_request):  # noqa: N802
     obj = Item()
     adapter = get_multi_adapter((obj, dummy_request), interface=IResourceSerializeToJson)

--- a/guillotina/tests/test_annotations.py
+++ b/guillotina/tests/test_annotations.py
@@ -10,9 +10,6 @@ import os
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 pytest.mark.skipif(os.environ.get("DATABASE") == "cockroachdb", reason="Flaky cockroachdb test")
 
 

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -19,9 +19,6 @@ import json
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 class ITestingRegistry(Interface):  # pylint: disable=E0239
     enabled = schema.Bool(title="Example attribute")
 

--- a/guillotina/tests/test_attachment.py
+++ b/guillotina/tests/test_attachment.py
@@ -11,9 +11,6 @@ import pytest
 import random
 
 
-pytestmark = pytest.mark.asyncio
-
-
 _pytest_params = [
     pytest.param("db", marks=pytest.mark.app_settings({"cloud_datamanager": "db"})),
     pytest.param(

--- a/guillotina/tests/test_auth.py
+++ b/guillotina/tests/test_auth.py
@@ -7,9 +7,6 @@ import jwt
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_jwt_auth(container_requester):
     async with container_requester as requester:
         from guillotina.auth.users import ROOT_USER_ID

--- a/guillotina/tests/test_blob.py
+++ b/guillotina/tests/test_blob.py
@@ -4,11 +4,6 @@ from guillotina.tests.utils import login
 from guillotina.transactions import transaction
 from guillotina.utils import get_database
 
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
-
 
 async def test_create_blob(db, guillotina_main):
     db = await get_database("db")

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -25,9 +25,6 @@ import os
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 NOT_POSTGRES = os.environ.get("DATABASE", "DUMMY") in ("cockroachdb", "DUMMY")
 PG_CATALOG_SETTINGS = {
     "applications": ["guillotina.contrib.catalog.pg"],

--- a/guillotina/tests/test_cockroach.py
+++ b/guillotina/tests/test_cockroach.py
@@ -10,7 +10,6 @@ import pytest
 
 
 pytestmark = [
-    pytest.mark.asyncio,
     pytest.mark.skipif(
         os.environ.get("DATABASE") != "cockroachdb", reason="These tests are only for cockroach"
     ),

--- a/guillotina/tests/test_commands.py
+++ b/guillotina/tests/test_commands.py
@@ -17,6 +17,7 @@ DATABASE = os.environ.get("DATABASE", "DUMMY")
 DB_SCHEMA = os.environ.get("DB_SCHEMA", "public")
 
 
+@pytest.mark.no_default_loop
 def test_run_command(command_arguments):
     _, filepath = mkstemp(suffix=".py")
     _, filepath2 = mkstemp()
@@ -37,6 +38,7 @@ async def run(app):
         assert fi.read() == "foobar"
 
 
+@pytest.mark.no_default_loop
 @pytest.mark.skipif(DATABASE != "postgres", reason="Only works with pg")
 @pytest.mark.skipif(DB_SCHEMA != "public", reason="Fixture 'container_command' does not support 'db_schema'")
 def test_run_command_with_container(command_arguments, container_command):
@@ -58,6 +60,7 @@ async def run(container):
         assert fi.read() == "foobar"
 
 
+@pytest.mark.no_default_loop
 @pytest.mark.skipif(DATABASE != "postgres", reason="Only works with pg")
 @pytest.mark.skipif(DB_SCHEMA != "public", reason="Fixture 'container_command' does not support 'db_schema'")
 def test_run_vacuum_with_container(command_arguments, container_command):
@@ -65,6 +68,7 @@ def test_run_vacuum_with_container(command_arguments, container_command):
     command.run_command(settings=container_command["settings"])
 
 
+@pytest.mark.no_default_loop
 @pytest.mark.skipif(DATABASE != "postgres", reason="Only works with pg")
 @pytest.mark.skipif(DB_SCHEMA != "public", reason="Fixture 'container_command' does not support 'db_schema'")
 def test_run_migration(command_arguments, container_command):
@@ -72,12 +76,14 @@ def test_run_migration(command_arguments, container_command):
     command.run_command(settings=container_command["settings"])
 
 
+@pytest.mark.no_default_loop
 def test_get_settings():
     settings = get_settings("doesnotexist.json", ["foobar=foobar", "foo.bar=foobar"])
     assert settings["foobar"] == "foobar"
     assert settings["foo"]["bar"] == "foobar"
 
 
+@pytest.mark.no_default_loop
 def test_get_settings_with_environment_variables():
     os.environ.update(
         {"G_foobar": "foobar", "G_foo__bar": "foobar", "G_foo__bar1__bar2": json.dumps({"foo": "bar"})}
@@ -88,6 +94,7 @@ def test_get_settings_with_environment_variables():
     assert settings["foo"]["bar1"]["bar2"] == {"foo": "bar"}
 
 
+@pytest.mark.no_default_loop
 def test_gen_key_command(command_arguments):
     command_arguments.key_type = "oct"
     command_arguments.key_size = 256

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -19,9 +19,6 @@ from zope.interface import Interface
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_register_service(container_requester):
     cur_count = len(configure.get_configurations("guillotina.tests", "service"))
 

--- a/guillotina/tests/test_content.py
+++ b/guillotina/tests/test_content.py
@@ -25,9 +25,6 @@ import pickle
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 class ICustomContentType(IItem):
 
     images = Dict(key_type=TextLine(), value_type=TextLine(), required=False, defaultFactory=dict)

--- a/guillotina/tests/test_contentapi.py
+++ b/guillotina/tests/test_contentapi.py
@@ -4,9 +4,6 @@ from guillotina.utils import get_content_path
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_contentapi_create(db, guillotina_main):
     async with ContentAPI(guillotina_main.root["db"]) as api:
         container = await api.create({"@type": "Container", "id": "foobar"})

--- a/guillotina/tests/test_cors.py
+++ b/guillotina/tests/test_cors.py
@@ -7,9 +7,6 @@ from guillotina.tests.utils import get_mocked_request
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_get_root(container_requester):
     async with container_requester as requester:
         value, status, headers = await requester.make_request(

--- a/guillotina/tests/test_dbobjects.py
+++ b/guillotina/tests/test_dbobjects.py
@@ -9,9 +9,6 @@ from zope.interface import implementer
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 @implementer(IResource)
 class ObjectTest(BaseObject):  # type: ignore
     pass

--- a/guillotina/tests/test_dynamic_schema.py
+++ b/guillotina/tests/test_dynamic_schema.py
@@ -11,9 +11,6 @@ import json
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 class IFoobarType(Interface):
     pass
 

--- a/guillotina/tests/test_errors.py
+++ b/guillotina/tests/test_errors.py
@@ -1,24 +1,19 @@
 from guillotina.exceptions import DeserializationError
 from guillotina.exceptions import ValueDeserializationError
 
-import pytest
 
-
-@pytest.mark.asyncio
 async def test_non_existing_container(container_requester):
     async with container_requester as requester:
         response, status = await requester("GET", "/db/non")
         assert status == 404
 
 
-@pytest.mark.asyncio
 async def test_non_existing_registry(container_requester):
     async with container_requester as requester:
         response, status = await requester("GET", "/db/guillotina/@registry/non")
         assert status == 404
 
 
-@pytest.mark.asyncio
 async def test_non_existing_type(container_requester):
     async with container_requester as requester:
         response, status = await requester("GET", "/db/guillotina/@types/non")

--- a/guillotina/tests/test_extrafieldattr.py
+++ b/guillotina/tests/test_extrafieldattr.py
@@ -1,9 +1,3 @@
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
-
-
 async def test_schema_extra(container_requester):
     async with container_requester as requester:
         resp, status = await requester("GET", "/db/guillotina/@types/Example")

--- a/guillotina/tests/test_files.py
+++ b/guillotina/tests/test_files.py
@@ -6,7 +6,6 @@ from guillotina.tests.utils import get_mocked_request
 import pytest
 
 
-@pytest.mark.asyncio
 async def test_read_request_data_handles_retries():
     request = get_mocked_request()
     request._retry_attempt = 1
@@ -15,7 +14,6 @@ async def test_read_request_data_handles_retries():
     assert await read_request_data(request, 5) == b"aaa"
 
 
-@pytest.mark.asyncio
 async def test_read_request_data_throws_exception_if_no_cache_data():
     request = get_mocked_request()
     request._retry_attempt = 1

--- a/guillotina/tests/test_guillo.py
+++ b/guillotina/tests/test_guillo.py
@@ -6,10 +6,6 @@ from guillotina.factory import make_app
 
 import json
 import logging
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_get_the_root(guillotina):

--- a/guillotina/tests/test_login.py
+++ b/guillotina/tests/test_login.py
@@ -3,10 +3,6 @@ from guillotina.testing import TESTING_SETTINGS
 
 import json
 import jwt
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_login(container_requester):

--- a/guillotina/tests/test_postgres.py
+++ b/guillotina/tests/test_postgres.py
@@ -15,9 +15,6 @@ import os
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 DATABASE = os.environ.get("DATABASE", "DUMMY")
 USE_RDMS = DATABASE != "DUMMY"
 

--- a/guillotina/tests/test_queue.py
+++ b/guillotina/tests/test_queue.py
@@ -5,10 +5,6 @@ from guillotina.component import get_utility
 from guillotina.tests import utils
 
 import asyncio
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 class AsyncMockView(View):

--- a/guillotina/tests/test_request.py
+++ b/guillotina/tests/test_request.py
@@ -2,10 +2,6 @@ from guillotina.tests.utils import make_mocked_request
 from multidict import CIMultiDict
 
 import asyncio
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_execute_futures():

--- a/guillotina/tests/test_security.py
+++ b/guillotina/tests/test_security.py
@@ -12,10 +12,6 @@ from guillotina.transactions import transaction
 from guillotina.utils import get_security_policy
 
 import json
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_get_guillotina(container_requester):

--- a/guillotina/tests/test_serialize.py
+++ b/guillotina/tests/test_serialize.py
@@ -22,9 +22,6 @@ import uuid
 import zope.interface
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_serialize_resource(dummy_request, mock_txn):
     content = create_content()
     serializer = get_multi_adapter((content, dummy_request), IResourceSerializeToJson)

--- a/guillotina/tests/test_server.py
+++ b/guillotina/tests/test_server.py
@@ -14,7 +14,6 @@ def test_make_app(dummy_guillotina):
     assert type(dummy_guillotina.router) == TraversalRouter
 
 
-@pytest.mark.asyncio
 async def test_trns_retries_with_app(container_requester):
     async with container_requester as requester:
         with mock.patch("guillotina.traversal.MatchInfo.handler") as handle_mock:  # noqa
@@ -26,7 +25,6 @@ async def test_trns_retries_with_app(container_requester):
             assert status == 409
 
 
-@pytest.mark.asyncio
 async def test_async_util_started_and_stopped(dummy_guillotina):
     util = get_utility(ITestAsyncUtility)
     util.state == "init"
@@ -46,7 +44,6 @@ async def test_async_util_started_and_stopped(dummy_guillotina):
     assert util2.state == "finalize"
 
 
-@pytest.mark.asyncio
 async def test_requester_with_default_settings(container_requester_server):
     async with container_requester_server as requester:
         assert requester.host == "127.0.0.1"
@@ -54,7 +51,6 @@ async def test_requester_with_default_settings(container_requester_server):
 
 
 @pytest.mark.app_settings({"test_server_settings": {"host": "0.0.0.0", "port": 1234}})
-@pytest.mark.asyncio
 async def test_requester_with_custom_settings(container_requester_server):
     async with container_requester_server as requester:
         assert requester.host == "0.0.0.0"

--- a/guillotina/tests/test_static.py
+++ b/guillotina/tests/test_static.py
@@ -1,11 +1,6 @@
 from guillotina.component import get_utility
 from guillotina.interfaces import IApplication
 
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
-
 
 async def test_get_static_folder(dummy_guillotina):
     root = get_utility(IApplication, name="root")

--- a/guillotina/tests/test_storages.py
+++ b/guillotina/tests/test_storages.py
@@ -9,9 +9,6 @@ import os
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 DATABASE = os.environ.get("DATABASE", "DUMMY")
 
 

--- a/guillotina/tests/test_swagger.py
+++ b/guillotina/tests/test_swagger.py
@@ -1,9 +1,6 @@
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 SWAGGER_SETTINGS = {"applications": ["guillotina.contrib.swagger"]}
 
 

--- a/guillotina/tests/test_transactions.py
+++ b/guillotina/tests/test_transactions.py
@@ -14,9 +14,6 @@ from guillotina.utils import get_object_by_uid
 import pytest
 
 
-pytestmark = pytest.mark.asyncio
-
-
 async def test_no_tid_created_for_reads(dummy_request, event_loop):
     tm = mocks.MockTransactionManager()
     trns = Transaction(tm, loop=event_loop, read_only=True)

--- a/guillotina/tests/test_traversal.py
+++ b/guillotina/tests/test_traversal.py
@@ -20,7 +20,6 @@ class CorsTestRenderer:
         }
 
 
-@pytest.mark.asyncio
 @pytest.mark.app_settings({"cors_renderer": "guillotina.tests.test_traversal.CorsTestRenderer"})
 async def test_apply_cors(guillotina_main):
     request = get_mocked_request()

--- a/guillotina/tests/test_urls.py
+++ b/guillotina/tests/test_urls.py
@@ -2,7 +2,6 @@ from guillotina.tests.utils import make_mocked_request
 from guillotina.utils import get_url
 
 import json
-import pytest
 
 
 def test_url(dummy_guillotina):
@@ -24,7 +23,6 @@ def test_forwarded_proto_url(dummy_guillotina):
     assert url.endswith("/c/d")
 
 
-@pytest.mark.asyncio
 async def test_url_of_object_with_vhm(container_requester):
     async with container_requester as requester:
         resp, _ = await requester(
@@ -36,7 +34,6 @@ async def test_url_of_object_with_vhm(container_requester):
         assert resp["@id"].startswith("https://foobar.com/foo/bar/db/guillotina")
 
 
-@pytest.mark.asyncio
 async def test_url_of_object_with_scheme(container_requester):
     async with container_requester as requester:
         resp, _ = await requester(

--- a/guillotina/tests/test_utils.py
+++ b/guillotina/tests/test_utils.py
@@ -10,7 +10,6 @@ from guillotina.utils import get_behavior
 from guillotina.utils.navigator import Navigator
 
 import json
-import pytest
 
 
 def test_module_resolve_path():
@@ -32,7 +31,6 @@ def test_dotted_name():
     assert utils.get_dotted_name(IResource) == "guillotina.interfaces.content.IResource"
 
 
-@pytest.mark.asyncio
 async def test_get_content_path(container_requester):
     async with container_requester as requester:
         response, status = await requester(
@@ -49,7 +47,6 @@ async def test_get_content_path(container_requester):
         await tm.abort(txn=txn)
 
 
-@pytest.mark.asyncio
 async def test_get_content_depth(container_requester):
     async with container_requester as requester:
         response, status = await requester(
@@ -127,7 +124,6 @@ def test_merge_dicts():
     assert result["foo"]["bar"] == 3
 
 
-@pytest.mark.asyncio
 async def test_get_containers(container_requester):
     async with container_requester:
         containers = [c async for c in utils.get_containers()]
@@ -138,7 +134,6 @@ def test_safe_unidecode():
     assert "foobar" == utils.safe_unidecode(b"foobar")
 
 
-@pytest.mark.asyncio
 async def test_object_utils(container_requester):
     async with container_requester as requester:
         response, status = await requester(
@@ -164,7 +159,6 @@ async def test_object_utils(container_requester):
         await tm.abort(txn=txn)
 
 
-@pytest.mark.asyncio
 async def test_run_async():
     def _test():
         return "foobar"
@@ -172,7 +166,6 @@ async def test_run_async():
     assert await utils.run_async(_test) == "foobar"
 
 
-@pytest.mark.asyncio
 async def test_navigator_preload(container_requester):
     async with container_requester as requester:
         response, status = await requester(
@@ -196,7 +189,6 @@ async def test_navigator_preload(container_requester):
         await tm.abort(txn=txn)
 
 
-@pytest.mark.asyncio
 async def test_navigator_get(container_requester):
     async with container_requester as requester:
         response, status = await requester(
@@ -246,7 +238,6 @@ async def test_navigator_get(container_requester):
         await tm.abort(txn=txn)
 
 
-@pytest.mark.asyncio
 async def test_get_behavior(container_requester):
     async with container_requester as requester:
         response, status = await requester(

--- a/guillotina/tests/test_ws.py
+++ b/guillotina/tests/test_ws.py
@@ -1,10 +1,6 @@
 from guillotina.testing import ADMIN_TOKEN
 
 import json
-import pytest
-
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_hello(guillotina, container_requester):


### PR DESCRIPTION
What do you think about using this library https://github.com/delfick/alt-pytest-asyncio ? It's very new and I don't think there is a lot of people using it, but it seems to work (except the test_commands.py that break everything)

`DATABASE=postgres pytest guillotina/ --ignore=guillotina/tests/test_commands.py`