### PR TITLE
Add localroles to @available-roles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.0a5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add localroles to @available-roles
+  [jordic]
 
 
 6.0.0a4 (2019-12-23)

--- a/guillotina/contrib/dbusers/services/roles.py
+++ b/guillotina/contrib/dbusers/services/roles.py
@@ -1,6 +1,7 @@
 from guillotina import configure
 from guillotina.api.service import Service
 from guillotina.auth.role import global_roles
+from guillotina.auth.role import local_roles
 from guillotina.interfaces import IContainer
 
 
@@ -10,8 +11,18 @@ from guillotina.interfaces import IContainer
     permission="guillotina.ManageUsers",
     summary="Get available roles on guillotina container",
     method="GET",
+    responses={
+        "200": {
+            "description": "List of available roles",
+            "content": {
+                "application/json": {
+                    "schema": {"type": {"array"}}
+                }
+            }
+        }
+    }
 )
 class AvailableRoles(Service):
     async def __call__(self):
-        roles = global_roles()
+        roles = global_roles() + local_roles()
         return roles

--- a/guillotina/contrib/dbusers/services/roles.py
+++ b/guillotina/contrib/dbusers/services/roles.py
@@ -14,13 +14,9 @@ from guillotina.interfaces import IContainer
     responses={
         "200": {
             "description": "List of available roles",
-            "content": {
-                "application/json": {
-                    "schema": {"type": {"array"}}
-                }
-            }
+            "content": {"application/json": {"schema": {"type": {"array"}}}},
         }
-    }
+    },
 )
 class AvailableRoles(Service):
     async def __call__(self):

--- a/guillotina/tests/dbusers/test_manage_users.py
+++ b/guillotina/tests/dbusers/test_manage_users.py
@@ -129,3 +129,12 @@ async def test_delete_user(dbusers_requester, user_data):
         # Check user is not there anymore
         _, status_code = await requester("GET", "/db/guillotina/@users/foobar")
         assert status_code == 404
+
+
+
+@pytest.mark.app_settings(settings.DEFAULT_SETTINGS)
+async def test_get_available_roles(dbusers_requester):
+    async with dbusers_requester as requester:
+        resp, status_code = await requester("GET", "/db/guillotina/@available-roles")
+        assert "guillotina.Anonymous" in resp
+        assert "guillotina.Manager" in resp

--- a/guillotina/tests/dbusers/test_manage_users.py
+++ b/guillotina/tests/dbusers/test_manage_users.py
@@ -131,7 +131,6 @@ async def test_delete_user(dbusers_requester, user_data):
         assert status_code == 404
 
 
-
 @pytest.mark.app_settings(settings.DEFAULT_SETTINGS)
 async def test_get_available_roles(dbusers_requester):
     async with dbusers_requester as requester:


### PR DESCRIPTION
To be able to use the permission system on gmi, we need to have an
endpoint to get declared roles for the running guillotina.
It's not enought with globalroles (these are mostly related to container
admin), we need also local roles.