### PR TITLE
[5.x] Be able to customize default required setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ CHANGELOG
 5.3.2 (unreleased)
 ------------------
 
-- Make `Field.required` a property with the configured value in `Field._required`.
-  To change default required behavior, you can monkey patch `Field._required = False`
+- Make `Field.required` an optional property. To change default required behavior,
+  you can monkey patch `IField['required'].default = False`
   [vangheem]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 5.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make `Field.required` a property with the configured value in `Field._required`.
+  To change default required behavior, you can monkey patch `Field._required = False`
+  [vangheem]
 
 
 5.3.1 (2020-01-02)

--- a/guillotina/schema/_bootstrapfields.py
+++ b/guillotina/schema/_bootstrapfields.py
@@ -103,7 +103,6 @@ class Field(Attribute):
     interface = None
     _Element__tagged_values = None
     _validators = None
-    _required = True
 
     def __init__(
         self,
@@ -155,6 +154,8 @@ class Field(Attribute):
         super(Field, self).__init__(__name__, __doc__)
         self.title = title
         self.description = description
+        if required is not None:
+            self.required = required
         self.readonly = readonly
         if constraint is not None:
             self.constraint = constraint
@@ -169,13 +170,6 @@ class Field(Attribute):
 
         if missing_value is not self.__missing_value_marker:
             self.missing_value = missing_value
-
-        if required is not None:
-            self._required = required
-
-    @property
-    def required(self):
-        return self._required
 
     def validator(self, func):
         if self._validators is None:

--- a/guillotina/schema/_bootstrapfields.py
+++ b/guillotina/schema/_bootstrapfields.py
@@ -103,13 +103,14 @@ class Field(Attribute):
     interface = None
     _Element__tagged_values = None
     _validators = None
+    _required = True
 
     def __init__(
         self,
         title="",
         description="",
         __name__="",
-        required=True,
+        required=None,
         readonly=False,
         constraint=None,
         default=None,
@@ -154,7 +155,6 @@ class Field(Attribute):
         super(Field, self).__init__(__name__, __doc__)
         self.title = title
         self.description = description
-        self.required = required
         self.readonly = readonly
         if constraint is not None:
             self.constraint = constraint
@@ -169,6 +169,13 @@ class Field(Attribute):
 
         if missing_value is not self.__missing_value_marker:
             self.missing_value = missing_value
+
+        if required is not None:
+            self._required = required
+
+    @property
+    def required(self):
+        return self._required
 
     def validator(self, func):
         if self._validators is None:


### PR DESCRIPTION
With this change, you can do `IField['required'].default = False` to make required `False` by default