### PR TITLE
Update Dockerfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update Dockerfile
+  [svx]
 
 
 5.3.2 (2020-01-03)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,12 @@ ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Install Python Setuptools
+# hadolint ignore=DL3008
 RUN apt-get update -y && \
-    apt-get install -y locales git-core gcc g++ netcat libxml2-dev \
-    libxslt-dev libz-dev python3-dev
+    apt-get install -y --no-install-recommends \
+	locales git-core gcc g++ netcat libxml2-dev \
+    	libxslt-dev libz-dev python3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
 
@@ -19,7 +22,9 @@ COPY requirements.txt /requirements.txt
 COPY VERSION /VERSION
 
 # Install with pip
+# hadolint ignore=DL3013
 RUN pip install -r /requirements.txt
 COPY . /app
+# hadolint ignore=DL3013
 RUN pip install /app
 # RUN pip install guillotina==$(cat VERSION) || pip install guillotina


### PR DESCRIPTION
This PR improves apt install in the Dockerfile.

With the following:

- adding `no-install-recommends`
- removing `apt cache`

The result is a smaller image:

Old: 760MB
New: 725MB
