### PR TITLE
Small bugfixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,6 @@ CHANGELOG
 
 6.0.0a6 (unreleased)
 --------------------
-
 - Fix bug on swagger with endpoints without explicit security declarations
   [jordic]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ CHANGELOG
 6.0.0a6 (unreleased)
 --------------------
 
+- Fix bug on swagger with endpoints without explicit security declarations
+  [jordic]
+
+- Fix bug on pgcatalog when using it without a request
+  [jordic]
+
 - More detailed information in ValidationErrors
   [masipcat]
 

--- a/guillotina/commands/shell.py
+++ b/guillotina/commands/shell.py
@@ -1,10 +1,8 @@
 from guillotina import task_vars
 from guillotina import utils
-from guillotina._settings import app_settings
 from guillotina.commands import Command
 from guillotina.component import get_utility
 from guillotina.interfaces import IApplication
-from guillotina.testing import TESTING_SETTINGS
 from guillotina.tests.utils import get_mocked_request
 from guillotina.tests.utils import login
 
@@ -123,7 +121,6 @@ Configured databases
         return self.banner.format("\n".join(db_ids))
 
     def run(self, arguments, settings, app):
-        app_settings["root_user"]["password"] = TESTING_SETTINGS["root_user"]["password"]
         root = get_utility(IApplication, name="root")
         request = get_mocked_request()
         login()

--- a/guillotina/contrib/catalog/pg.py
+++ b/guillotina/contrib/catalog/pg.py
@@ -135,7 +135,6 @@ class Parser(BaseParser):
             return self.process_compound_field(field, value, " AND ")
 
         result: typing.Any = value
-
         operator = "="
         if field.endswith("__not"):
             operator = "!="
@@ -202,7 +201,6 @@ class Parser(BaseParser):
 
     def __call__(self, params: typing.Dict) -> ParsedQueryInfo:
         query_info = super().__call__(params)
-
         wheres = []
         arguments = []
         selects = []
@@ -601,7 +599,6 @@ class PGSearchUtility(DefaultSearchUtility):
         sql, arguments = self.build_query(container, query, ["id", "zoid", "json"])
         txn = get_current_transaction()
         conn = await txn.get_connection()
-
         results = []
         fullobjects = query["fullobjects"]
         try:
@@ -610,7 +607,7 @@ class PGSearchUtility(DefaultSearchUtility):
         except RequestNotFound:
             context_url = get_content_path(container)
             request = None
-            txn = None
+
         logger.debug(f"Running search:\n{sql}\n{arguments}")
         async with txn.lock:
             records = await conn.fetch(sql, *arguments)

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -37,10 +37,11 @@ class SwaggerDefinitionService(Service):
         desc = self.get_data(service_def.get("description", ""))
         swagger_conf = service_def.get("swagger", {})
         if swagger_conf.get("display_permission", True):
+            perms = service_def.get("permission", "")
             if desc:
-                desc += f" 〜 permission: {service_def['permission']}"
+                desc += f" 〜 permission: {perms}"
             else:
-                desc += f"permission: {service_def['permission']}"
+                desc += f"permission: {perms}"
 
         api_def[path or "/"][method.lower()] = {
             "tags": swagger_conf.get("tags", [""]) or tags,


### PR DESCRIPTION
- Don't brake swagger endpoints with services without explicit security
declarations.
- Be able to use pgcatalog without a request (from commands for example)
- Cleanup old death code on shell command