### PR TITLE
Add attribute 'view_dotted_name' in request object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 6.0.0a7 (unreleased)
 --------------------
 
+- Add attribute 'view_dotted_name' in request object
+  [masipcat]
+
 - Fix validating array params in query parameters [lferran]
 
 - Add open api tests and fix ones that do not pass tests

--- a/guillotina/interfaces/misc.py
+++ b/guillotina/interfaces/misc.py
@@ -15,6 +15,7 @@ class IRequest(Interface):
     exc: Optional[Exception]
     found_view: Optional[Type]
     view_name: Optional[str]
+    view_dotted_name: str
     application: Optional[IApplication]
 
     def record(event_name) -> None:

--- a/guillotina/request.py
+++ b/guillotina/request.py
@@ -284,6 +284,7 @@ class Request(object):
     application: Optional[IApplication] = None
     exc = None
     view_name = None
+    view_dotted_name = ""
     found_view = None
     resource: Optional[IBaseObject] = None
     tail = None

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -45,6 +45,7 @@ from guillotina.response import HTTPUnauthorized
 from guillotina.security.utils import get_view_permission
 from guillotina.transactions import abort
 from guillotina.transactions import commit
+from guillotina.utils import get_dotted_name
 from guillotina.utils import get_registry
 from guillotina.utils import get_security_policy
 from guillotina.utils import import_class
@@ -471,6 +472,7 @@ class TraversalRouter:
             raise HTTPNotFound(content={"reason": "object and/or route not found"})
 
         request.found_view = view
+        request.view_dotted_name = get_view_dotted_name(view)
         request.view_name = view_name
         request.record("viewfound")
 
@@ -513,3 +515,13 @@ class TraversalRouter:
             return await traverse(request, self._root, path)
         else:  # pragma: no cover
             raise ApplicationNotFound()
+
+
+def get_view_dotted_name(view):
+    try:
+        try:
+            return get_dotted_name(view.view_func)
+        except AttributeError:
+            return get_dotted_name(view)
+    except AttributeError:
+        return None


### PR DESCRIPTION
@vangheem @bloodbare I open this PR to discuss how to access some request attributes from a middleware. guillotina_prometheus needs `request.found_view` to label the observed metric, but some request attributes are cleared after the traversal. I see two solutions:

1. Add `request.view_dotted_name` for the use-case of prometheus
2. Move the request cleanup logic after this line: https://github.com/plone/guillotina/blob/master/guillotina/asgi.py#L113