### PR TITLE
[5.x] Be able to customize db name in tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ CHANGELOG
 5.3.20 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Be able to customize pg db in test fixtures
+  [vangheem]
 
 5.3.19 (2020-02-01)
 -------------------

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -790,8 +790,8 @@ WHERE tablename = '{}' AND indexname = '{}_parent_id_id_key';
     async def remove(self):
         """Reset the tables"""
         async with self.pool.acquire() as conn:
-            await conn.execute("DROP TABLE IF EXISTS {};".format(self._blobs_table_name))
-            await conn.execute("DROP TABLE IF EXISTS {};".format(self._objects_table_name))
+            await conn.execute("DROP TABLE IF EXISTS {} CASCADE;".format(self._blobs_table_name))
+            await conn.execute("DROP TABLE IF EXISTS {} CASCADE;".format(self._objects_table_name))
 
     @restart_conn_on_exception
     async def open(self):

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -125,7 +125,11 @@ def get_db_settings(pytest_node=None):
         "password": "",
     }
 
-    options = dict(host=annotations.get("pg_host", "localhost"), port=annotations.get("pg_port", 5432))
+    options = dict(
+        host=annotations.get("pg_host", "localhost"),
+        port=annotations.get("pg_port", 5432),
+        dbname=annotations.get("pg_db", "guillotina"),
+    )
 
     if annotations["testdatabase"] == "cockroachdb":
         configure_db(settings["databases"]["db"], **options, user="root", storage="cockroach")

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -118,7 +118,7 @@ def get_db_settings(pytest_node=None):
 
     settings["databases"]["db"]["dsn"] = {
         "scheme": "postgres",
-        "dbname": "guillotina",
+        "dbname": annotations.get("pg_db", "guillotina"),
         "user": "postgres",
         "host": annotations.get("pg_host", "localhost"),
         "port": annotations.get("pg_port", 5432),


### PR DESCRIPTION
This is only useful if you are customizing how the pg tests are done. I need to be able to dynamically set the db name used in tests and this allows me to do it.