### PR TITLE
docs(roles): add link to permissions.py

### DIFF
--- a/docs/source/developer/roles.md
+++ b/docs/source/developer/roles.md
@@ -34,7 +34,7 @@ Anonymous user has on DB/StaticFiles/StaticDirectories/Application object :
 
 Defined at:
 
- * guillotina/permissions.py
+ * [guillotina/permissions.py](https://github.com/plone/guillotina/blob/master/guillotina/permissions.py "Link to permissions.py on GitHub")
 
 ## Content Related
 


### PR DESCRIPTION
This PR adds a link to `permissions.py` in the docs about roles.

The advantage is that readers/devs can now find the find with less effort, because the docs pointing to it.
This is also handy if you want to link to parts of the guillotina docs in your reference documentation.