### PR TITLE
docs(sphinx): update copyright date

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Guillotina"
-copyright = "2016, Ramon Navarro Bosch & Nathan Van Gheem"
+copyright = "2020, Ramon Navarro Bosch & Nathan Van Gheem"
 author = "Ramon Navarro Bosch & Nathan Van Gheem"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This PR updates the "copyright date" in the footer to 2020.

This is not adding value to the docs as in content and it is maybe less important for developers but it adds a general value :)

Sorry I was not able to resist 😄 .

![Screenshot 2020-02-07 at 15 12 36](https://user-images.githubusercontent.com/358860/74036557-c7069c80-49bc-11ea-95be-ebe03430cf40.png)

The date in the image shown above  ⬆️ will change to 2020.