### PR TITLE
docs(about): add links - improve rst syntax and layout

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -6,41 +6,45 @@ Guillotina is part of that evolution, providing an asynchronous web server
 with a rich, REST-ful API to build your web applications around.
 
 It is designed for building JavaScript applications. It is an API framework, not
-a typical template-based rendering framework like most web frameworks (Django/Pyramid/Plone).
+a typical template-based rendering framework like most web frameworks (`Django <https://www.djangoproject.com/>`_/`Pyramid <https://trypyramid.com/>`_/`Plone <htps://plone.org>`_).
+
 What we mean by this is that Guillotina will not generate HTML out-of-the-box for you.
 It is designed to be consumed by JavaScript applications that do the HTML rendering,
 or to act as a middleware layer on a microservice architecture.
 
 
 Features:
-  - REST JSON API
-  - Built-in authentication/authorization, built-in JWT support
-  - Hierarchical data/url structure
-  - Permissions/roles/groups
-  - Fully customizable permission/roles/groups based on hierarchical data structure
-  - Robust customizable component architecture and configuration syntax
-  - Content types, dynamic behaviors
-  - Built-in CORS support
-  - JSON schema support
-  - PostgreSQL and CockroachDB drivers
-  - Blobs
+
+- REST JSON API
+- Built-in authentication/authorization, built-in JWT support
+- Hierarchical data/url structure
+- Permissions/roles/groups
+- Fully customizable permission/roles/groups based on hierarchical data structure
+- Robust customizable component architecture and configuration syntax
+- Content types, dynamic behaviors
+- Built-in CORS support
+- JSON schema support
+- PostgreSQL and CockroachDB drivers
+- Blobs
 
 Guillotina is built on the lessons learned from great technologies of the
-open source projects Plone, Zope, Pyramid and Django.
+open source projects Plone, `Zope <https://www.zope.org/>`_, Pyramid and Django.
 
 Inspirations:
- - Plone/Zope's hierarchical data model
- - Pyramid's decorator-based auto-discovery application configuration syntax
- - Django's global application settings style syntax
- - Zope's component architecture for building robustly customizable applications
- - Plone/Zope's security model
- - JSON Schema
+
+- Plone/Zope's hierarchical data model
+- Pyramid's decorator-based auto-discovery application configuration syntax
+- Django's global application settings style syntax
+- Zope's component architecture for building robustly customizable applications
+- Plone/Zope's security model
+- JSON Schema
 
 
 Lessons Learned (from said inspired frameworks):
- - Trade-offs for the sake of performance is okay
- - Too many complex dependencies causes difficulties in management and upgrades
- - It's okay to fork dependency packages
+
+- Trade-offs for the sake of performance is okay
+- Too many complex dependencies causes difficulties in management and upgrades
+- It's okay to fork dependency packages
 
 
 History lesson
@@ -53,7 +57,9 @@ urls. It's an old idea. A beautiful idea. The developers of Guillotina think
 it's the best possible way to conceptualize most content-centric APIs and
 organization of how your web applications think about data or their APIs.
 
-Think about this simple example. Assuming you have the following dictionary::
+Think about this simple example. Assuming you have the following dictionary
+
+.. code-block:: python
 
     {
       "foo": {
@@ -62,9 +68,10 @@ Think about this simple example. Assuming you have the following dictionary::
     }
 
 The corresponding urls for a site based off this dictionary would be:
- - http://localhost:8080/
- - http://localhost:8080/foo
- - http://localhost:8080/foo/bar
+
+- http://localhost:8080/
+- http://localhost:8080/foo
+- http://localhost:8080/foo/bar
 
 And so on... It's a simple way to build APIs from data around a hierarchy (or tree).
 
@@ -81,13 +88,13 @@ At the beginning there is the notion of Content-Type. A content type, it's just
 a python interface (A class) that describes an object. Every object could be stored
 on the db. And every object, could have child objects related to them. Something like:
 
-/user@account/
-/user@account/preferences
-/user@account/todos
-/user@account/todos/todos_list1
-/user@account/todos/todos_list1/todo_item1
-/user@account/todos/todos_list1/todo_item2
-/user@account/todos/todos_list1/todo_item3
+| /user@account/
+| /user@account/preferences
+| /user@account/todos
+| /user@account/todos/todos_list1
+| /user@account/todos/todos_list1/todo_item1
+| /user@account/todos/todos_list1/todo_item2
+| /user@account/todos/todos_list1/todo_item3
 
 Allows us to better express content relations, and this is where guillotina shines, because
 it offers an automatic REST API over them.
@@ -105,32 +112,31 @@ other users.
 
 Security is accessed throught /object_path/@sharing
 
-
-
-
 Forked dependency packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Guillotina has eaten a few packages that would have otherwise been dependencies.
 
 The reasons for forking are:
-  - Required to support asyncio
-  - Provide tighter fit for framework
-  - Make installations less painful and error-prone
-  - Groking framework is easier when there is one package to import from
+
+- Required to support asyncio
+- Provide tighter fit for framework
+- Make installations less painful and error-prone
+- Groking framework is easier when there is one package to import from
 
 
 Forks:
-  - parts of the ZODB data model: we're on a relational storage model now
-  - plone.behavior
-  - zope.security
-  - zope.schema
-  - zope.component/zope.configuration
-  - zope.dublincore
-  - zope.i18n
-  - zope.lifecycleevent
-  - zope.location
-  - zope.event
+
+- parts of the ZODB data model: we're on a relational storage model now
+- plone.behavior
+- zope.security
+- zope.schema
+- zope.component/zope.configuration
+- zope.dublincore
+- zope.i18n
+- zope.lifecycleevent
+- zope.location
+- zope.event
 
 
 What it isn't
@@ -140,5 +146,4 @@ What it isn't
 - Guillotina is not a re-implementation of Plone
 - Guillotina does not implement all the features and APIs of Plone
 
-It could come some day with the `guillotina_cms` package but replacement of Plone is
-not the goal of Guillotina.
+It could come some day with the `guillotina_cms` package but replacement of Plone is not the goal of Guillotina.


### PR DESCRIPTION
This PR improves the file `about.rst` by:

- Adding links to Plone/Zope/Pyramid/Django
- Adding code-blocks
- Improve `reST` syntax (lists and such)

Pics (rst-preview)

![Screenshot 2020-02-07 at 16 53 05](https://user-images.githubusercontent.com/358860/74043931-857cee00-49ca-11ea-8a4e-49fbf3553b44.png)

![Screenshot 2020-02-07 at 16 53 23](https://user-images.githubusercontent.com/358860/74043934-86ae1b00-49ca-11ea-9fdb-54bd27b89f3f.png)
