### PR TITLE
docs(advanced): add links, fix typos

### DIFF
--- a/docs/source/developer/advanced.md
+++ b/docs/source/developer/advanced.md
@@ -2,10 +2,11 @@
 
 ## Running Guillotina on another ASGI server
 
-Guillotina supoprt the following ASGI servers out-of-the-box:
+Guillotina supports the following ASGI ([Asynchronous Server Gateway Interface](https://asgi.readthedocs.io/en/latest/index.html "Link to ASGI spec."))
+servers out-of-the-box:
 
-- `uvicorn` (used by default)
-- `hypercorn`
+- [Uvicorn](https://www.uvicorn.org/ "Link to Uvicorn") (used by default)
+- [Hypercorn](https://pgjones.gitlab.io/hypercorn/ "Link to Hypercorn")
 
 Use the argument `--asgi-server` to choose one of the previous servers:
 
@@ -13,11 +14,11 @@ Use the argument `--asgi-server` to choose one of the previous servers:
 guillotina serve -c config.yaml --asgi-server=hypercorn
 ```
 
-You can use any other ASGI server by using `guillotina.entrypoint:app` as the app and the environment variable `G_CONFIG_FILE` to specificy the configuration file.
+You can use any other ASGI server by using `guillotina.entrypoint:app` as the app and the environment variable `G_CONFIG_FILE` to specify the configuration file.
 
-**Example:**
+### Example
 
-Running guillotina on `hypercorn` with QUIC support:
+Running Guillotina on Hypercorn with [QUIC](https://en.wikipedia.org/wiki/QUIC "Link to QUIC") support:
 
 ```shell
 G_CONFIG_FILE=config.yaml hypercorn --quic-bind 127.0.0.1:4433 guillotina.entrypoint:app


### PR DESCRIPTION
This PR updates `docs/source/advanced.md` with the following changes:

- Add link to ASGI
- Add explanation for ASGI
- Add link to Uvicorn
- Add link to Hypercorn
- Add link to QUIC
- Fix typos