### PR TITLE
docker(dockerignore): add more files to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,11 @@ docker-compose.yml
 CODEOWNERS
 docker_push
 Makefile
+README.rst
+CHANGELOG.rst
+performance-data.md
+.travis.yml
+.gitignore
+.readthedocs.yml
+.codecov.yml
+.coveragerc


### PR DESCRIPTION
This PR adds more files to *.dockerignore*.

By doing so, these files are not ending up in the container (AFAIK, these are not needed in the container).

Less files to copy = faster builds, smaller images and less overhead in the container :) 