### PR TITLE
docs(swagger): add openapi

### DIFF
--- a/docs/source/contrib/swagger.md
+++ b/docs/source/contrib/swagger.md
@@ -11,7 +11,7 @@ applications:
 
 ## Usage
 
-Once activated, visit `http://localhost:8080/@docs` to view swagger documentation.
+Once activated, visit `http://localhost:8080/@docs` to view OpenAPI documentation.
 
 Make sure to click the `Authenticate` button to specify root location to load swagger
 definitions for and provide username/password to authenticate with.

--- a/docs/source/contrib/swagger.md
+++ b/docs/source/contrib/swagger.md
@@ -13,5 +13,8 @@ applications:
 
 Once activated, visit `http://localhost:8080/@docs` to view OpenAPI documentation.
 
-Make sure to click the `Authenticate` button to specify root location to load swagger
-definitions for and provide username/password to authenticate with.
+Make sure to click the `Authenticate` button to specify the root location to load the OpenAPI definitions.
+
+.. note::
+
+    You need to provide username/password to authenticate with.

--- a/docs/source/contrib/swagger.md
+++ b/docs/source/contrib/swagger.md
@@ -1,7 +1,6 @@
 # Swagger
 
-Guillotina provides out of the box swagger support.
-
+Guillotina provides out of the box OpenAPI (Swagger) support.
 
 ## Configuration
 
@@ -11,7 +10,6 @@ applications:
 ```
 
 ## Usage
-
 
 Once activated, visit `http://localhost:8080/@docs` to view swagger documentation.
 


### PR DESCRIPTION
This PR updates `docs/contrib/swagger.md` by updating terminology.

It reads now: *Guillotina provides out of the box OpenAPI (Swagger) support.*

