### PR TITLE
docs(readme): update install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Using pip (requires Python > 3.7)
     python3.7 -m venv .
     ./bin/pip install -r requirements.txt
     ./bin/pip install -r contrib-requirements.txt
-    ./bin/pip install -e .[test]
+    ./bin/pip install -e '.[test]'
     ./bin/pre-commit install
 
 


### PR DESCRIPTION
This PR changes:

`./bin/pip install -e .[test]` to `./bin/pip install -e '.[test]'`

With this change I was able to run `pip`, before the change `pip` was stopping and complaining :) 