### PR TITLE
 Improve performance of bucket dict field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.26 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve performance of bucket dict field
+  [vangheem]
 
 
 5.3.25 (2020-02-11)

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -1,4 +1,5 @@
 from asyncio import shield
+from guillotina import glogging
 from guillotina._settings import app_settings
 from guillotina.const import TRASHED_ID
 from guillotina.db.events import StorageCreatedEvent
@@ -20,12 +21,11 @@ import asyncio
 import asyncpg
 import asyncpg.connection
 import concurrent
-import logging
 import time
 import ujson
 
 
-log = logging.getLogger("guillotina.storage")
+log = glogging.getLogger("guillotina.storage")
 
 
 # we can not use FOR UPDATE or FOR SHARE unfortunately because

--- a/guillotina/fields/annotation.py
+++ b/guillotina/fields/annotation.py
@@ -278,7 +278,7 @@ class BucketDictValue:
             annotation = await self.get_annotation(context, key)
 
         insert_idx = bisect.bisect_left(annotation["keys"], key)
-        if len(annotation["keys"]) < insert_idx and annotation["keys"][insert_idx] == key:
+        if len(annotation["keys"]) > insert_idx and annotation["keys"][insert_idx] == key:
             # change existing value
             annotation["values"][insert_idx] = value
         else:

--- a/guillotina/tests/test_annotations.py
+++ b/guillotina/tests/test_annotations.py
@@ -5,9 +5,11 @@ from guillotina.interfaces import IAnnotations
 from guillotina.tests.utils import login
 from guillotina.transactions import transaction
 from guillotina.utils import get_database
+from uuid import uuid4
 
 import os
 import pytest
+import time
 
 
 pytest.mark.skipif(os.environ.get("DATABASE") == "cockroachdb", reason="Flaky cockroachdb test")
@@ -94,3 +96,17 @@ async def test_bucket_dict_value(db, guillotina_main):
         assert [k async for k in bucket.iter_keys(ob)] == [str(i) for i in _range]
         assert [v async for v in bucket.iter_values(ob)] == [i for i in _range]
         assert [(k, v) async for k, v in bucket.iter_items(ob)] == [(str(i), i) for i in _range]
+
+
+async def _test_bucket_dict_value_many_values(dummy_guillotina):
+    db = await get_database("db")
+    login()
+    bucket = BucketDictValue(bucket_len=20000)
+
+    async with transaction(db=db):
+        container = await create_content_in_container(db, "Container", "container", title="Container")
+        ob = await create_content_in_container(container, "Item", "foobar")
+        start = time.time()
+        for index in range(61000):
+            await bucket.assign(ob, str(uuid4()), index)
+        print(f"done in {time.time() - start}")

--- a/guillotina/tests/test_annotations.py
+++ b/guillotina/tests/test_annotations.py
@@ -98,7 +98,7 @@ async def test_bucket_dict_value(db, guillotina_main):
         assert [(k, v) async for k, v in bucket.iter_items(ob)] == [(str(i), i) for i in _range]
 
 
-async def _test_bucket_dict_value_many_values(dummy_guillotina):
+async def _test_bucket_dict_value_many_values(dummy_guillotina):  # pragma: no cover
     db = await get_database("db")
     login()
     bucket = BucketDictValue(bucket_len=20000)


### PR DESCRIPTION
Using bisect instead of index on large-ish lists gives us almost 10x performance.

`guillotina/tests/test_annotations.py done in 17.738866090774536`

vs

`guillotina/tests/test_annotations.py done in 1.9164221286773682`