### PR TITLE
docs(training): update note to warning

### DIFF
--- a/docs/source/training/configuration.md
+++ b/docs/source/training/configuration.md
@@ -44,7 +44,7 @@ docker run \
 
 
 ```eval_rst
-.. note::
+.. warning::
    This particular docker run command produces a volatile database.
 
    Stopping and starting it again will cause you to lose any data you pushed into it.


### PR DESCRIPTION
This PR updates the info box from a **Note** to a **Warning**.

The intention here is that this is important to know, and because that we want to highlight that in a different color than we do with a note :) 