### PR TITLE
docs(training): update install instructions

### DIFF
--- a/docs/source/training/installation.md
+++ b/docs/source/training/installation.md
@@ -6,22 +6,23 @@ and [Docker](https://www.docker.com/ "Link to Docker's website").
 Please make sure that you have both installed.
 
 ```eval_rst
-.. note::
-   It is recommended you install along with a venv::
-
-      python3.7 -m venv genv
-      cd genv
-      source ./bin/activate
+.. note:: It is recommended you install along with a `virtual environment <https://docs.python.org/3/library/venv.html>`_
 ```
 
-``` shell
+```shell
+python3.7 -m venv genv
+cd genv
+source ./bin/activate
+```
+
+```shell
 pip install guillotina
 ```
 
 For the purpose of this training, you'll also need to install
 [Cookiecutter](https://cookiecutter.readthedocs.io/en/latest/ "Link to Cookiecutter's website").
 
-``` shell
+```shell
 pip install cookiecutter
 ```
 


### PR DESCRIPTION
This PR updates the install instructions of the training by:

- Improving code-blocks
- Adding link to Python docs about virtual environments