### PR TITLE
Changed error handling logic in ErrorsMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,12 @@ CHANGELOG
 6.0.0a13 (unreleased)
 ---------------------
 
-- Breaking API change: Search GET 
+- Changed error handling logic: Guillotina (asgi app) catches all errors and returns a
+  response for the ones that implements the handler IErrorResponseException. Otherwise
+  raises the exception and is handled by ErrorsMiddleware
+  [masipcat]
+
+- Breaking API change: Search GET
   Search get responds a json with items and items_total like plone rest api
   [bloodbare]
 

--- a/guillotina/asgi.py
+++ b/guillotina/asgi.py
@@ -1,15 +1,21 @@
 from guillotina import glogging
 from guillotina import task_vars
+from guillotina.browser import View
+from guillotina.component import query_adapter
 from guillotina.exc_resp import HTTPConflict
 from guillotina.exceptions import ConflictError
 from guillotina.exceptions import TIDConflictError
+from guillotina.interfaces import IErrorResponseException
 from guillotina.middlewares import ErrorsMiddleware
 from guillotina.request import Request
+from guillotina.response import Response
+from guillotina.traversal import apply_rendering
 from guillotina.utils import resolve_dotted_name
 
 import asyncio
 import enum
 import traceback
+import uuid
 
 
 logger = glogging.getLogger("guillotina")
@@ -144,15 +150,31 @@ class Guillotina:
         self.router = router
 
     async def __call__(self, scope, receive, send):
+        """
+        This method always returns a response object or raises a Exception for
+        unhandled errors
+        """
         request_settings = {
             k: v for k, v in self.asgi_app.server_settings.items() if k in ("client_max_size",)
         }
         request = Request.factory(scope, send, receive, **request_settings)
         task_vars.request.set(request)
 
-        resp = await self.request_handler(request)
+        try:
+            return await self.request_handler(request)
+        except Response as exc:
+            return exc
+        except Exception as exc:
+            # Try to render exception using IErrorResponseException
+            eid = uuid.uuid4().hex
+            view_result = query_adapter(
+                exc, IErrorResponseException, kwargs={"error": "ServiceError", "eid": eid}
+            )
+            if view_result is not None:
+                return await apply_rendering(View(None, request), request, view_result)
 
-        return resp
+            # Raise unhandled exceptions to ErrorMiddleware
+            raise
 
     async def request_handler(self, request, retries=0):
         try:

--- a/guillotina/middlewares/errors.py
+++ b/guillotina/middlewares/errors.py
@@ -4,10 +4,7 @@ from guillotina import response
 from guillotina import task_vars
 from guillotina._settings import app_settings
 from guillotina.browser import View
-from guillotina.component import query_adapter
 from guillotina.i18n import default_message_factory as _
-from guillotina.interfaces import IErrorResponseException
-from guillotina.response import Response
 from guillotina.traversal import apply_rendering
 
 import asyncio
@@ -29,15 +26,11 @@ class ErrorsMiddleware:
 
         try:
             resp = await self.next_app(scope, receive, _send)
-        except (Exception, Response) as exc:
-            if not headers_sent:
-                request = task_vars.request.get()
-                if isinstance(exc, Response):
-                    view_result = exc
-                else:
-                    view_result = self.generate_error_response(exc, None, "ServiceError")
-                resp = await apply_rendering(View(None, request), request, view_result)
-            else:
+        except Exception as exc:
+            request = task_vars.request.get()
+            view_result = self.generate_error_response(exc, None, "ServiceError")
+            resp = await apply_rendering(View(None, request), request, view_result)
+            if headers_sent:
                 # Too late to send status 500, headers already sent
                 raise
         return resp
@@ -45,9 +38,6 @@ class ErrorsMiddleware:
     def generate_error_response(self, e, request, error, status=500):
         # We may need to check the roles of the users to show the real error
         eid = uuid.uuid4().hex
-        http_response = query_adapter(e, IErrorResponseException, kwargs={"error": error, "eid": eid})
-        if http_response is not None:
-            return http_response
         if isinstance(e, asyncio.CancelledError):  # pragma: no cover
             message = _("Cancelled execution of view") + " " + eid
             logger.warning(message, exc_info=e, eid=eid, request=request)


### PR DESCRIPTION
 Changed error handling logic: Guillotina (asgi app) catches all errors and returns a response for the ones that implements the handler IErrorResponseException. Otherwise raises the exception and is handled by ErrorsMiddleware.

The motivation behind this change is that Sentry middleware was capturing `DeserializationErrors` and `PrecondionFailed` exceptions