### PR TITLE
github action - publish docker images

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,28 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+    - name: Get the version
+      id: vars
+      run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+
+    - name: Build the tagged Docker image
+      run: docker build . --file Dockerfile --tag guillotina/guillotina:${{steps.vars.outputs.tag}}
+    - name: Push the tagged Docker image
+      run: docker push guillotina/guillotina:${{steps.vars.outputs.tag}}
+
+    - name: Build the latest Docker image
+      run: docker build . --file Dockerfile --tag guillotina/guillotina:latest
+    - name: Push the latest Docker image
+      run: docker push guillotina/guillotina:latest


### PR DESCRIPTION
#911


Edit:
Setting secrets for dockerhub authentication. (Repository settings -> secrets)
![image](https://user-images.githubusercontent.com/42739235/74944798-dba05700-53f6-11ea-9abb-74ca229c9aec.png)
More info: [Github docs](https://help.github.com/es/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)