### PR TITLE
docker(dockerignore): remove readme and changelog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,6 @@ docker-compose.yml
 CODEOWNERS
 docker_push
 Makefile
-README.rst
-CHANGELOG.rst
 performance-data.md
 .travis.yml
 .gitignore


### PR DESCRIPTION
This PR removes *README.rst* and *CHANGELOG.rst* form `.dockerignore`.

Sorry for breaking the image builds!

I was a bit too fast and forgetting to check *setup.py*

