### PR TITLE
docs(readme): add docker hub badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ Introduction
    :target: https://gitter.im/plone/guillotina
    :alt: Chat
 
+.. image:: https://img.shields.io/docker/cloud/build/plone/guillotina
+   :target: https://hub.docker.com/r/guillotina/guillotina
+   :alt: Docker Cloud Build Status
+
 Please `read the detailed docs <http://guillotina.readthedocs.io/en/latest/>`_
 
 


### PR DESCRIPTION
This PR adds a new badge to the top of the README.

This badge links to Guillotina on Docker Hub, here is a pic:

![Screenshot 2020-02-21 at 12 29 57](https://user-images.githubusercontent.com/358860/75031242-144b3980-54a6-11ea-8f6a-e7c4ad741ced.png)
