### PR TITLE
Reverted "Replaced Response.content_{type,length} with Response.set_content_{type,length}". Using setter to avoid breaking `Response.content_{type,length} = ...`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 6.0.0a14 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Reverted "Replaced Response.content_{type,length} with Response.set_content_{type,length}".
+  Using setter to avoid breaking `Response.content_{type,length} = ...`
+  [masipcat]
 
 
 6.0.0a13 (2020-02-20)

--- a/guillotina/response.py
+++ b/guillotina/response.py
@@ -89,13 +89,13 @@ class Response(Exception):
     def content_type(self):
         self.headers.get(istr("Content-Type"))
 
-    @property
-    def content_length(self):
-        self.headers.get(istr("Content-Length"))
-
     @content_type.setter
     def content_type(self, content_type):
         self.headers[istr("Content-Type")] = content_type
+
+    @property
+    def content_length(self):
+        self.headers.get(istr("Content-Length"))
 
     @content_length.setter
     def content_length(self, content_length):

--- a/guillotina/response.py
+++ b/guillotina/response.py
@@ -63,9 +63,9 @@ class Response(Exception):
         self.headers: CIMultiDict = headers
 
         if content_type:
-            self.set_content_type(content_type)
+            self.content_type = content_type
         if content_length:
-            self.set_content_length(content_length)
+            self.content_length = content_length
 
         self._prepared = False
         self._start_body = False
@@ -83,12 +83,22 @@ class Response(Exception):
         self.content = None
         self.body = body
         if content_type is not None:
-            self.set_content_type(content_type)
+            self.content_type = content_type
 
-    def set_content_type(self, content_type):
+    @property
+    def content_type(self):
+        self.headers.get(istr("Content-Type"))
+
+    @property
+    def content_length(self):
+        self.headers.get(istr("Content-Length"))
+
+    @content_type.setter
+    def content_type(self, content_type):
         self.headers[istr("Content-Type")] = content_type
 
-    def set_content_length(self, content_length):
+    @content_length.setter
+    def content_length(self, content_length):
         self.headers[istr("Content-Length")] = str(content_length)
 
     @property

--- a/guillotina/response.py
+++ b/guillotina/response.py
@@ -87,7 +87,7 @@ class Response(Exception):
 
     @property
     def content_type(self):
-        self.headers.get(istr("Content-Type"))
+        return self.headers.get(istr("Content-Type"))
 
     @content_type.setter
     def content_type(self, content_type):
@@ -95,7 +95,7 @@ class Response(Exception):
 
     @property
     def content_length(self):
-        self.headers.get(istr("Content-Length"))
+        return self.headers.get(istr("Content-Length"))
 
     @content_length.setter
     def content_length(self, content_length):

--- a/guillotina/tests/test_static.py
+++ b/guillotina/tests/test_static.py
@@ -14,9 +14,10 @@ async def test_get_static_folder(dummy_guillotina):
 
 async def test_render_static_file(container_requester):
     async with container_requester as requester:
-        response, status = await requester("GET", "/static/tests/teststatic.txt")
+        response, status, headers = await requester.make_request("GET", "/static/tests/teststatic.txt")
         assert status == 200
         assert response.decode("utf8").strip() == "foobar"
+        assert headers["Content-Type"] == "text/plain"
 
 
 async def test_render_javascript_app(container_requester):


### PR DESCRIPTION
Closes https://github.com/plone/guillotina/issues/920