### PR TITLE
Change AttributeError to HTTPPreconditionFailed in FileManager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 6.0.0a14 (unreleased)
 ---------------------
 
+- Change AttributeError to HTTPPreconditionFailed in FileManager
+  [masipcat]
+
 - Reverted "Replaced Response.content_{type,length} with Response.set_content_{type,length}".
   Using setter to avoid breaking `Response.content_{type,length} = ...`
   [masipcat]

--- a/guillotina/files/manager.py
+++ b/guillotina/files/manager.py
@@ -420,7 +420,9 @@ class FileManager(object):
             if "Content-Length" in self.request.headers:
                 size = int(self.request.headers["Content-Length"])
             else:  # pragma: no cover
-                raise AttributeError("x-upload-size or content-length header needed")
+                raise HTTPPreconditionFailed(
+                    content={"reason": "x-upload-size or content-length header needed"}
+                )
 
         if "X-UPLOAD-FILENAME" in self.request.headers:
             filename = self.request.headers["X-UPLOAD-FILENAME"]


### PR DESCRIPTION
The main problem with AttributeError is that the view crashes with 500 and the exception goes to sentry