### PR TITLE
Fix move(obj) fires IBeforeObjectMovedEvent after modifying the object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix move(obj) fires IBeforeObjectMovedEvent after modifying the object
+  [masipcat]
 
 
 6.0.0b1 (2020-03-18)

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -800,16 +800,14 @@ async def move(
         cache_keys = txn._cache.get_cache_keys(context, "deleted")
 
     old_id = context.id
-    if new_id is not None:
-        context.id = context.__name__ = new_id
-    else:
+    if new_id is None:
         new_id = context.id
 
     if check_permission:
         policy = get_security_policy()
         if not policy.check_permission("guillotina.AddContent", destination_ob):
             raise PreconditionFailed(
-                context, "You do not have permission to add content to the " "destination object"
+                context, "You do not have permission to add content to the destination object"
             )
 
     if await destination_ob.async_contains(new_id):
@@ -828,6 +826,8 @@ async def move(
         )
     )
 
+    if new_id != old_id:
+        context.id = context.__name__ = new_id
     context.__parent__ = destination_ob
     context.register()
 


### PR DESCRIPTION
Close https://github.com/plone/guillotina/issues/941