### PR TITLE
Change in ISecurityPolicy that might improve performance during traversal for views with permission guillotina.Public

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,19 @@ CHANGELOG
 6.0.0b3 (unreleased)
 --------------------
 
+- Change in ISecurityPolicy that might improve performance during traversal for views
+  with permission guillotina.Public
+  [masipcat]
+
 - Change log level for conflict errors to warning and fix locating tid of conflict error
-  [vangheem] 
+  [vangheem]
 
 - Fix security policy not taking into account IInheritPermissionMap for principals
   [masipcat,bloodbare]
 
 
 - Fix use of int32 sql interpolation when it should have been bigint for tid
-  [vangheem] 
+  [vangheem]
 
 - Restore task vars after usage of Content API
 - Zope.interface 5.0.1 upgrade

--- a/guillotina/security/policy.py
+++ b/guillotina/security/policy.py
@@ -62,7 +62,7 @@ class SecurityPolicy:
     @profilable
     def check_permission(self, permission, obj):
         # Always allow public attributes
-        if permission is Public:
+        if permission == Public:
             return True
 
         if IView.providedBy(obj):


### PR DESCRIPTION
I haven't measured the benefit of this change, but I think it might have a positive impact on applications that have a lot of request on public endpoints (like our case in @Vinissimus)