### PR TITLE
fix tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 6.0.0b4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- swagger tags fixes
 
 
 6.0.0b3 (2020-04-24)

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -77,7 +77,7 @@ class SwaggerDefinitionService(Service):
                     {"in": "path", "name": route_part, "schema": {"type": "string"}, "required": True}
                 )
         api_def[path or "/"][method.lower()] = {
-            "tags": swagger_conf.get("tags", [""]) or tags,
+            "tags": swagger_conf.get("tags", []) or tags,
             "parameters": parameters,
             "requestBody": request_body,
             "summary": self.get_data(service_def.get("summary", "")),
@@ -95,7 +95,7 @@ class SwaggerDefinitionService(Service):
                         iface_conf["endpoints"][name],
                         os.path.join(base_path, name),
                         api_def,
-                        tags=[name.strip("@")],
+                        tags=tags or [name.strip("@")],
                     )
             else:
                 if method.lower() == "options":


### PR DESCRIPTION
some fixes for tags:
- in `services/get_endpoints`:  check if there are tags supplied in the args
- in `services/load_swagger_info`: change default to empty array so user supplied tags will be allowed