### PR TITLE
Path params containing paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.0b5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Allow arbitrary path parameter within the path parameters
+  [dmanchon]
 
 
 6.0.0b4 (2020-05-23)

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -74,7 +74,12 @@ class SwaggerDefinitionService(Service):
             route_part = route_part.strip("{}")
             if route_part not in [p["name"] for p in parameters if p.get("in") == "path"]:
                 parameters.append(
-                    {"in": "path", "name": route_part, "schema": {"type": "string"}, "required": True}
+                    {
+                        "in": "path",
+                        "name": route_part.replace(":path", ""),
+                        "schema": {"type": "string"},
+                        "required": True,
+                    }
                 )
         api_def[path.replace(":path", "") or "/"][method.lower()] = {
             "tags": swagger_conf.get("tags", []) or tags,

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -76,7 +76,7 @@ class SwaggerDefinitionService(Service):
                 parameters.append(
                     {"in": "path", "name": route_part, "schema": {"type": "string"}, "required": True}
                 )
-        api_def[path or "/"][method.lower()] = {
+        api_def[path.replace(":path", "") or "/"][method.lower()] = {
             "tags": swagger_conf.get("tags", []) or tags,
             "parameters": parameters,
             "requestBody": request_body,

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -33,7 +33,7 @@ class SwaggerDefinitionService(Service):
     def load_swagger_info(self, api_def, path, method, tags, service_def):
         path = path.rstrip("/")
         if path not in api_def:
-            api_def[path or "/"] = {}
+            api_def[path.replace(":path", "") or "/"] = {}
         desc = self.get_data(service_def.get("description", ""))
         swagger_conf = service_def.get("swagger", {})
         try:

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -18,7 +18,6 @@ import pkg_resources
 
 here = os.path.dirname(os.path.realpath(__file__))
 
-
 @configure.service(
     method="GET", context=Interface, name="@swagger", permission="guillotina.swagger.View", ignore=True
 )
@@ -31,9 +30,9 @@ class SwaggerDefinitionService(Service):
         return data
 
     def load_swagger_info(self, api_def, path, method, tags, service_def):
-        path = path.rstrip("/")
+        path = path.rstrip("/").replace(":path", "")
         if path not in api_def:
-            api_def[path.replace(":path", "") or "/"] = {}
+            api_def[path or "/"] = {}
         desc = self.get_data(service_def.get("description", ""))
         swagger_conf = service_def.get("swagger", {})
         try:
@@ -73,6 +72,7 @@ class SwaggerDefinitionService(Service):
         for route_part in [r for r in service_def["route"] if r[0] == "{"]:
             route_part = route_part.strip("{}")
             if route_part not in [p["name"] for p in parameters if p.get("in") == "path"]:
+
                 parameters.append(
                     {
                         "in": "path",
@@ -81,7 +81,7 @@ class SwaggerDefinitionService(Service):
                         "required": True,
                     }
                 )
-        api_def[path.replace(":path", "") or "/"][method.lower()] = {
+        api_def[path or "/"][method.lower()] = {
             "tags": swagger_conf.get("tags", []) or tags,
             "parameters": parameters,
             "requestBody": request_body,

--- a/guillotina/contrib/swagger/services.py
+++ b/guillotina/contrib/swagger/services.py
@@ -18,6 +18,7 @@ import pkg_resources
 
 here = os.path.dirname(os.path.realpath(__file__))
 
+
 @configure.service(
     method="GET", context=Interface, name="@swagger", permission="guillotina.swagger.View", ignore=True
 )

--- a/guillotina/routes.py
+++ b/guillotina/routes.py
@@ -81,7 +81,7 @@ class Route:
             self.route_parts.append(RoutePart(parts[0]))
             for part in parts[1:]:
                 if part.endswith(":path}"):
-                    self.view_name += "?"
+                    self.view_name = parts[0] + "?"
                     name = part.replace(":path", "").strip("{").strip("}")
                     self.route_parts.append(PathRoutePart(name))
                     break

--- a/guillotina/routes.py
+++ b/guillotina/routes.py
@@ -92,7 +92,6 @@ class Route:
                     else:
                         self.route_parts.append(RoutePart(part))
 
-
     def matches(self, request, path_parts):
         matchdict = {"__parts": path_parts}
         for idx, route_part in enumerate(self.route_parts):

--- a/guillotina/routes.py
+++ b/guillotina/routes.py
@@ -21,6 +21,14 @@ class RoutePart:
         return self.name
 
 
+class PathRoutePart(RoutePart):
+    def matches(self, other):
+        return True
+
+    def __str__(self):
+        return "{" + self.name + ":path}"
+
+
 class VariableRoutePart(RoutePart):
     def matches(self, other):
         return True
@@ -72,16 +80,25 @@ class Route:
             self.view_name = parts[0]
             self.route_parts.append(RoutePart(parts[0]))
             for part in parts[1:]:
-                self.view_name += "/"
-                if URL_MATCH_RE.match(part):
-                    self.route_parts.append(VariableRoutePart(part.strip("{").strip("}")))
+                if part.endswith(":path}"):
+                    self.view_name += "?"
+                    name = part.replace(":path", "").strip("{").strip("}")
+                    self.route_parts.append(PathRoutePart(name))
+                    break
                 else:
-                    self.route_parts.append(RoutePart(part))
+                    self.view_name += "/"
+                    if URL_MATCH_RE.match(part):
+                        self.route_parts.append(VariableRoutePart(part.strip("{").strip("}")))
+                    else:
+                        self.route_parts.append(RoutePart(part))
+
 
     def matches(self, request, path_parts):
         matchdict = {"__parts": path_parts}
         for idx, route_part in enumerate(self.route_parts):
-            if route_part.matches(path_parts[idx]):
+            if isinstance(route_part, PathRoutePart):
+                matchdict[route_part.name] = "/".join(path_parts[idx:])
+            elif route_part.matches(path_parts[idx]):
                 matchdict[route_part.name] = path_parts[idx]
             else:
                 raise KeyError(route_part.name)

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -260,7 +260,9 @@ async def test_register_service_with_path(container_requester):
             return {"path": path}
 
     configure.register_configuration(
-        TestService, dict(context=IContainer, name="@foobar/{path:path}", permission="guillotina.ViewContent"), "service"
+        TestService,
+        dict(context=IContainer, name="@foobar/{path:path}", permission="guillotina.ViewContent"),
+        "service",
     )
 
     assert len(configure.get_configurations("guillotina.tests", "service")) == cur_count + 1  # noqa

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -262,7 +262,11 @@ async def test_register_service_with_path(container_requester):
 
     configure.register_configuration(
         TestService,
-        dict(context=IContainer, name="@foobar/endpoint/{component}/{filepath:path}", permission="guillotina.ViewContent"),
+        dict(
+            context=IContainer,
+            name="@foobar/endpoint/{component}/{filepath:path}",
+            permission="guillotina.ViewContent",
+        ),
         "service",
     )
 

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -256,12 +256,13 @@ async def test_register_service_with_path(container_requester):
 
     class TestService(Service):
         async def __call__(self):
-            path = self.request.matchdict["path"]
-            return {"path": path}
+            path = self.request.matchdict["filepath"]
+            component = self.request.matchdict["component"]
+            return {"filepath": path, "component": component}
 
     configure.register_configuration(
         TestService,
-        dict(context=IContainer, name="@foobar/{path:path}", permission="guillotina.ViewContent"),
+        dict(context=IContainer, name="@foobar/endpoint/{component}/{filepath:path}", permission="guillotina.ViewContent"),
         "service",
     )
 
@@ -272,5 +273,5 @@ async def test_register_service_with_path(container_requester):
         configure.load_configuration(config, "guillotina.tests", "service")
         config.execute_actions()
 
-        response, status = await requester("GET", "/db/guillotina/@foobar/root/folder/another")
-        assert response["path"] == "root/folder/another"
+        response, status = await requester("GET", "/db/guillotina/@foobar/endpoint/comp1/root/folder/another")
+        assert response["filepath"] == "root/folder/another"

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -249,3 +249,26 @@ async def test_app_settings_are_overwritten_by_pytest_marks(container_requester)
     assert app_settings["databases"]["db"]["read_only"] == "yo"
     # Check that other keys that were previously there are untouched
     assert "storage" in app_settings["databases"]["db"]
+
+
+async def test_register_service_with_path(container_requester):
+    cur_count = len(configure.get_configurations("guillotina.tests", "service"))
+
+    class TestService(Service):
+        async def __call__(self):
+            path = self.request.matchdict["path"]
+            return {"path": path}
+
+    configure.register_configuration(
+        TestService, dict(context=IContainer, name="@foobar/{path:path}", permission="guillotina.ViewContent"), "service"
+    )
+
+    assert len(configure.get_configurations("guillotina.tests", "service")) == cur_count + 1  # noqa
+
+    async with container_requester as requester:
+        config = requester.root.app.config
+        configure.load_configuration(config, "guillotina.tests", "service")
+        config.execute_actions()
+
+        response, status = await requester("GET", "/db/guillotina/@foobar/root/folder/another")
+        assert response["path"] == "root/folder/another"

--- a/guillotina/tests/test_routes.py
+++ b/guillotina/tests/test_routes.py
@@ -32,3 +32,7 @@ def test_convert_path_to_view_name():
 
 def test_convert_non_route_path_to_view_name():
     assert routes.path_to_view_name("foobar/foo/bar") == "foobar//"
+
+
+def test_convert_path_route_to_view_name():
+    assert routes.Route("@foobar/{p:path}").view_name == "@foobar?"

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -447,9 +447,14 @@ class TraversalRouter:
                     )
 
         if not view and len(tail) > 0:
-            # we should have a view in this case because we are matching routes
-            await notify(TraversalViewMissEvent(request, tail))
-            raise HTTPNotFound(content={"reason": "object and/or route not found"})
+            # Try arbitrary "path" in the path
+            try:
+                view_name = tail[0] + "?"
+                view = query_multi_adapter((resource, request), method, name=view_name)
+            except AttributeError:
+                # we should have a view in this case because we are matching routes
+                await notify(TraversalViewMissEvent(request, tail))
+                raise HTTPNotFound(content={"reason": "object and/or route not found"})
 
         request.found_view = view
         request.view_name = view_name

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -448,10 +448,9 @@ class TraversalRouter:
 
         if not view and len(tail) > 0:
             # Try arbitrary "path" in the path
-            try:
-                view_name = tail[0] + "?"
-                view = query_multi_adapter((resource, request), method, name=view_name)
-            except AttributeError:
+            view_name = tail[0] + "?"
+            view = query_multi_adapter((resource, request), method, name=view_name)
+            if not view:
                 # we should have a view in this case because we are matching routes
                 await notify(TraversalViewMissEvent(request, tail))
                 raise HTTPNotFound(content={"reason": "object and/or route not found"})

--- a/guillotina/traversal.py
+++ b/guillotina/traversal.py
@@ -446,11 +446,11 @@ class TraversalRouter:
                         }
                     )
 
-        if not view and len(tail) > 0:
+        if view is None and len(tail) > 0:
             # Try arbitrary "path" in the path
             view_name = tail[0] + "?"
             view = query_multi_adapter((resource, request), method, name=view_name)
-            if not view:
+            if view is None:
                 # we should have a view in this case because we are matching routes
                 await notify(TraversalViewMissEvent(request, tail))
                 raise HTTPNotFound(content={"reason": "object and/or route not found"})


### PR DESCRIPTION
I wonder if accepting actual paths in the path parameter (something like this in fastapi: https://fastapi.tiangolo.com/tutorial/path-params/#path-parameters-containing-paths) could be nice to have.

So defining a service with `@api/get_path/{path:path}` with the request`@api/get_path/folder1/2/3` request will capture path as "/folder/1/2/3"