### PR TITLE
[5.x] Fix and optimize json schema validate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,12 @@ CHANGELOG
 5.3.43 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Optimize json schema ref resolution to not make so copies of all json schema definition
+  for every validator instance
+  [vangheem]
+
+- Fix json schema ref resolution for nested objects
+  [vangheem]
 
 
 5.3.42 (2020-05-26)

--- a/guillotina/api/service.py
+++ b/guillotina/api/service.py
@@ -11,6 +11,7 @@ from guillotina.response import HTTPNotFound
 from guillotina.response import HTTPPreconditionFailed
 from guillotina.schema import Dict
 from guillotina.utils import get_schema_validator
+from guillotina.utils import JSONSchemaRefResolver
 from typing import Any
 from typing import Dict as TDict
 from typing import List as TList
@@ -141,7 +142,9 @@ class Service(View):
                     try:
                         cls.__schema__ = schema
                         jsonschema_validator = jsonschema.validators.validator_for(cls.__schema__)
-                        cls.__validator__ = jsonschema_validator(cls.__schema__)
+                        cls.__validator__ = jsonschema_validator(
+                            cls.__schema__, resolver=JSONSchemaRefResolver.from_schema(schema)
+                        )
                     except jsonschema.exceptions.ValidationError:  # pragma: no cover
                         logger.warning("Could not validate schema", exc_info=True)
             else:

--- a/guillotina/tests/test_jsonschema.py
+++ b/guillotina/tests/test_jsonschema.py
@@ -7,6 +7,7 @@ from guillotina.interfaces import IResourceFactory
 from guillotina.interfaces import ISchemaFieldSerializeToJson
 from guillotina.json.utils import convert_interfaces_to_schema
 from guillotina.utils import get_schema_validator
+from guillotina.utils import JSONSchemaRefResolver
 from zope.interface import Interface
 
 import jsonschema
@@ -153,3 +154,15 @@ async def test_serialize_factory_to_json(dummy_guillotina, dummy_request):
     assert data["properties"]["guillotina.behaviors.dublincore.IDublinCore"] == {
         "$ref": "#/components/schemas/guillotina.behaviors.dublincore.IDublinCore"
     }
+
+
+async def test_resolve_json_schema_type(dummy_guillotina):
+    resolver = JSONSchemaRefResolver(base_uri="/", referrer=None)
+    resolver.resolve_fragment(None, "/components/schemas/Behavior")
+    resolver.resolve_fragment(None, "/components/schemas/Resource")
+
+    with pytest.raises(jsonschema.exceptions.RefResolutionError):
+        resolver.resolve_fragment({}, "/components/schemas/Foobar")
+
+    with pytest.raises(NotImplementedError):
+        resolver.resolve_remote("http://foobar.com")

--- a/guillotina/tests/test_jsonschema.py
+++ b/guillotina/tests/test_jsonschema.py
@@ -162,6 +162,9 @@ async def test_resolve_json_schema_type(dummy_guillotina):
     resolver.resolve_fragment(None, "/components/schemas/Resource")
 
     with pytest.raises(jsonschema.exceptions.RefResolutionError):
+        resolver.resolve_fragment({}, "/foo/bar/Foobar")
+
+    with pytest.raises(jsonschema.exceptions.RefResolutionError):
         resolver.resolve_fragment({}, "/components/schemas/Foobar")
 
     with pytest.raises(NotImplementedError):

--- a/guillotina/utils/__init__.py
+++ b/guillotina/utils/__init__.py
@@ -27,6 +27,7 @@ from .misc import get_registry  # noqa
 from .misc import get_request_scheme  # noqa
 from .misc import get_schema_validator  # noqa
 from .misc import get_url  # noqa
+from .misc import JSONSchemaRefResolver  # noqa
 from .misc import lazy_apply  # noqa
 from .misc import list_or_dict_items  # noqa
 from .misc import load_task_vars  # noqa

--- a/guillotina/utils/misc.py
+++ b/guillotina/utils/misc.py
@@ -1,5 +1,4 @@
 from collections import MutableMapping
-from collections.abc import Sequence
 from functools import partial
 from guillotina import glogging
 from guillotina import task_vars

--- a/stubs/jsonschema/validators/__init__.py
+++ b/stubs/jsonschema/validators/__init__.py
@@ -2,11 +2,20 @@ from typing import Any
 from typing import Dict
 
 
+class RefResolver:
+    @classmethod
+    def from_schema(cls, schema) -> "RefResolver":
+        ...
+
+
 class Validator:
+    def __init__(self):
+        ...
+
     def check_schema(self, schema: Dict[str, Any]):
         ...
 
-    def __call__(self, schema: Dict[str, Any]) -> "Validator":
+    def __call__(self, schema: Dict[str, Any], resolver: RefResolver) -> "Validator":
         ...
 
 


### PR DESCRIPTION
We were not able to reference json schema types in services unless they were on the top level.