### PR TITLE
Catch invalid value types for registry modifications

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ CHANGELOG
 6.0.0b6 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix registry update, when type provided mismatch with the one specified
+  by the schema return an error HTTP status code instead of throwing an
+  exception.
+  [pfreixes]
 
 
 6.0.0b5 (2020-06-08)

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -28,6 +28,7 @@ pytestmark = pytest.mark.asyncio
 
 class ITestingRegistry(Interface):  # pylint: disable=E0239
     enabled = schema.Bool(title="Example attribute")
+    test_type = schema.Int(title="Example attribute")
 
 
 class ITestingRegistryUpdated(Interface):  # pylint: disable=E0239
@@ -276,6 +277,15 @@ async def test_register_registry(container_requester):
             "/db/guillotina/@registry/guillotina.tests.test_api.ITestingRegistry.enabled",
             data=json.dumps({"v": False}),
         )
+        assert status == 412
+
+        # Type validation
+        response, status = await requester(
+            "PATCH",
+            "/db/guillotina/@registry/guillotina.tests.test_api.ITestingRegistry.test_type",
+            data=json.dumps({"value": ["Im not an integer"]}),
+        )
+        print(response)
         assert status == 412
 
         response, status = await requester(


### PR DESCRIPTION
When a new value for a specific registry is provided and the framework
complains that the type is not valid return a 412 instead of returning
a generic 500 error