### PR TITLE
Also allow JWT sub claim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Also allow JWT sub claim for loginid
+  [allusa]
 
 
 6.0.0 (2020-06-17)

--- a/guillotina/auth/utils.py
+++ b/guillotina/auth/utils.py
@@ -54,7 +54,7 @@ def authenticate_user(userid, data=None, timeout=60 * 60 * 1):
     if data is None:
         data = {}
     data.update(
-        {"iat": datetime.utcnow(), "exp": datetime.utcnow() + timedelta(seconds=timeout), "id": userid}
+        {"iat": datetime.utcnow(), "exp": datetime.utcnow() + timedelta(seconds=timeout), "id": userid, "sub": userid}
     )
     jwt_token = jwt.encode(
         data, app_settings["jwt"]["secret"], algorithm=app_settings["jwt"]["algorithm"]

--- a/guillotina/auth/utils.py
+++ b/guillotina/auth/utils.py
@@ -54,7 +54,12 @@ def authenticate_user(userid, data=None, timeout=60 * 60 * 1):
     if data is None:
         data = {}
     data.update(
-        {"iat": datetime.utcnow(), "exp": datetime.utcnow() + timedelta(seconds=timeout), "id": userid, "sub": userid}
+        {
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=timeout),
+            "id": userid,
+            "sub": userid,
+        }
     )
     jwt_token = jwt.encode(
         data, app_settings["jwt"]["secret"], algorithm=app_settings["jwt"]["algorithm"]

--- a/guillotina/auth/validators.py
+++ b/guillotina/auth/validators.py
@@ -130,7 +130,7 @@ class JWTValidator:
             validated_jwt = jwt.decode(
                 token["token"], app_settings["jwt"]["secret"], algorithms=[app_settings["jwt"]["algorithm"]]
             )
-            token["id"] = validated_jwt["id"]
+            token["id"] = validated_jwt.get("id", validated_jwt.get("sub"))
             token["decoded"] = validated_jwt
             user = await find_user(token)
             if user is not None and user.id == token["id"]:


### PR DESCRIPTION
Allow loginid to be defined in the _sub_ (subject) JWT claim. Also maintain the private Guillotina _id_ claim.