### PR TITLE
Fix bug trying to deserialize jsonschema validation error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 6.0.9 (unreleased)
 ------------------
 
+- Fix bug on error deserialization [lferran]
+
 - Fix transaction context manager doesn't abort the txn when a exception is raised
   [masipcat]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 6.0.9 (unreleased)
 ------------------
 
-- Fix bug on error deserialization [lferran]
+- Fix bug on error deserialization
 
 - Fix transaction context manager doesn't abort the txn when a exception is raised
   [masipcat]

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -4,6 +4,7 @@ from zope.interface import implementer
 from zope.interface.exceptions import Invalid  # noqa pylint: disable=W0611
 from zope.interface.interfaces import ComponentLookupError  # noqa pylint: disable=W0611
 
+import jsonschema
 import orjson
 
 
@@ -218,12 +219,10 @@ class DeserializationError(Exception):
                 if hasattr(exc, "errors") and exc.errors:
                     inner_errors = []
                     for e in exc.errors:
-                        try:
+                        if isinstance(e, jsonschema.exceptions.ValidationError):
+                            inner_errors.append({"message": e.message})
+                        else:
                             inner_errors.append(e.json())
-                        except AttributeError:
-                            # jsonschema.exceptions.ValidationError
-                            # does not have json() method
-                            inner_errors.append({"error_str": str(e)})
                     error["errors"] = self.json_err_list(inner_errors)
             converted_errors.append(error)
         return converted_errors

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -221,10 +221,9 @@ class DeserializationError(Exception):
                         try:
                             inner_errors.append(e.json())
                         except AttributeError:
-                            # TODO:
                             # jsonschema.exceptions.ValidationError
                             # does not have json() method
-                            pass
+                            inner_errors.append({"error_str": str(e)})
                     error["errors"] = self.json_err_list(inner_errors)
             converted_errors.append(error)
         return converted_errors

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -216,7 +216,16 @@ class DeserializationError(Exception):
             if "error" in error:
                 exc = error.pop("error")
                 if hasattr(exc, "errors") and exc.errors:
-                    error["errors"] = self.json_err_list([e.json() for e in exc.errors])
+                    inner_errors = []
+                    for e in exc.errors:
+                        try:
+                            inner_errors.append(e.json())
+                        except AttributeError:
+                            # TODO:
+                            # jsonschema.exceptions.ValidationError
+                            # does not have json() method
+                            pass
+                    error["errors"] = self.json_err_list(inner_errors)
             converted_errors.append(error)
         return converted_errors
 

--- a/guillotina/json/deserialize_content.py
+++ b/guillotina/json/deserialize_content.py
@@ -102,7 +102,6 @@ class DeserializeFromJson:
         write_permissions = merged_tagged_value_dict(schema, write_permission.key)
         changed = False
         for name, field in get_fields(schema).items():
-
             if name in RESERVED_ATTRS:
                 continue
 

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -78,7 +78,7 @@ class IExample(IResource):
     text_field = schema.Text(required=False)
     dict_value = schema.Dict(key_type=schema.TextLine(), value_type=schema.TextLine(), required=False)
     datetime = schema.Datetime(required=False)
-
+    jsonfield_value = schema.JSONField(schema={"type": "array"}, required=False)
     write_permission(write_protected="example.MyPermission")
     write_protected = schema.TextLine(title="Write protected field", required=False)
 

--- a/guillotina/tests/test_errors.py
+++ b/guillotina/tests/test_errors.py
@@ -28,6 +28,13 @@ async def test_non_existing_type(container_requester):
         assert status == 404
 
 
+@pytest.mark.asyncio
+async def test_non_(container_requester):
+    async with container_requester as requester:
+        response, status = await requester("GET", "/db/guillotina/@types/non")
+        assert status == 404
+
+
 def test_deserialization_error_formats_error():
     error = DeserializationError([{"error": "Foobar", "field": "foobar_field"}])
     assert "foobar_field" in str(error)
@@ -85,3 +92,26 @@ async def test_handled_exception(container_requester):
             handle_mock.side_effect = DeserializationError([{"err": "bad error"}])
             _, status = await requester("GET", "/db")
             assert status == 412
+
+
+@pytest.mark.asyncio
+async def test_jsonfield_json_schema_validation_error_is_deserialized(container_requester):
+    import json
+
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST", "/db/guillotina", data=json.dumps({"@type": "Example", "id": "foobar"})
+        )
+        assert status == 201
+        response, status = await requester(
+            "PATCH",
+            "/db/guillotina/foobar",
+            data=json.dumps(
+                {
+                    # Send an invalid type
+                    "jsonfield_value": {}
+                }
+            ),
+        )
+        assert status == 412
+        assert "{} is not of type 'array'" in response["deserialization_errors"][0]["errors"][0]["error_str"]

--- a/guillotina/tests/test_errors.py
+++ b/guillotina/tests/test_errors.py
@@ -28,13 +28,6 @@ async def test_non_existing_type(container_requester):
         assert status == 404
 
 
-@pytest.mark.asyncio
-async def test_non_(container_requester):
-    async with container_requester as requester:
-        response, status = await requester("GET", "/db/guillotina/@types/non")
-        assert status == 404
-
-
 def test_deserialization_error_formats_error():
     error = DeserializationError([{"error": "Foobar", "field": "foobar_field"}])
     assert "foobar_field" in str(error)
@@ -114,4 +107,4 @@ async def test_jsonfield_json_schema_validation_error_is_deserialized(container_
             ),
         )
         assert status == 412
-        assert "{} is not of type 'array'" in response["deserialization_errors"][0]["errors"][0]["error_str"]
+        assert "{} is not of type 'array'" in response["deserialization_errors"][0]["errors"][0]["message"]


### PR DESCRIPTION
This is happening for fields with `schema.JSONField` type, if a type that doesn't match the schema is sent. 