### PR TITLE
Pass 'server_settings' in 'connection_options' to asyncpg pool

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pass 'server_settings' in 'connection_options' to asyncpg pool
+  [masipcat]
 
 
 6.0.5 (2020-08-11)

--- a/guillotina/db/factory.py
+++ b/guillotina/db/factory.py
@@ -36,6 +36,7 @@ def _get_connection_options(dbconfig):
         "max_cached_statement_lifetime",
         "max_cacheable_statement_size",
         "command_timeout",
+        "server_settings",
     ):
         if key in dbconfig:
             connection_options[key] = dbconfig[key]


### PR DESCRIPTION
Close https://github.com/vinissimus/product/issues/2938

With this change I can define the following config:

```yaml
  db:
    storage: postgresql
    dsn: postgresql://...
    server_settings:
      application_name: api
```

and see the `application_name` of the process/connection in `pg_stat_activity`:

```sql
SELECT                              
  pid,
  application_name, 
  state
FROM pg_stat_activity
```

This was proposed by @jordic 