### PR TITLE
Add IFileNameGenerator adapter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add IFileNameGenerator adapter
+  [qiwn]
 
 
 6.0.6 (2020-08-25)

--- a/guillotina/files/adapter.py
+++ b/guillotina/files/adapter.py
@@ -9,9 +9,12 @@ from guillotina.events import FileUploadFinishedEvent
 from guillotina.events import FileUploadStartedEvent
 from guillotina.exceptions import BlobChunkNotFound
 from guillotina.exceptions import FileNotFoundException
+from guillotina.files.utils import generate_key
 from guillotina.files.utils import guess_content_type
 from guillotina.interfaces import IDBFileField
 from guillotina.interfaces import IFileCleanup
+from guillotina.interfaces import IFileField
+from guillotina.interfaces import IFileNameGenerator
 from guillotina.interfaces import IFileStorageManager
 from guillotina.interfaces import IRequest
 from guillotina.interfaces import IResource
@@ -20,6 +23,16 @@ from guillotina.response import HTTPPreconditionFailed
 from typing import AsyncIterator
 
 import time
+
+
+@configure.adapter(for_=(IResource, IFileField), provides=IFileNameGenerator)
+class FileNameGenerator:
+    def __init__(self, context, field):
+        self.context = context
+        self.field = field
+
+    def __call__(self):
+        return generate_key(self.context)
 
 
 @configure.adapter(for_=IFileStorageManager, provides=IUploadDataManager, name="db")

--- a/guillotina/files/utils.py
+++ b/guillotina/files/utils.py
@@ -87,6 +87,4 @@ def guess_content_type(content_type, filename):
 
 
 def generate_key(context):
-    return "{}{}/{}::{}".format(
-        task_vars.container.get().id, get_content_path(context), context.__uuid__, uuid.uuid4().hex
-    )
+    return "{}/{}::{}".format(task_vars.container.get().id, context.__uuid__, uuid.uuid4().hex)

--- a/guillotina/files/utils.py
+++ b/guillotina/files/utils.py
@@ -1,6 +1,7 @@
 from .const import MAX_REQUEST_CACHE_SIZE
 from guillotina import task_vars
 from guillotina.exceptions import UnRetryableRequestError
+from guillotina.utils import get_content_path
 from guillotina.utils import to_str
 
 import asyncio
@@ -86,4 +87,6 @@ def guess_content_type(content_type, filename):
 
 
 def generate_key(context):
-    return "{}/{}::{}".format(task_vars.container.get().id, context.__uuid__, uuid.uuid4().hex)
+    return "{}{}/{}::{}".format(
+        task_vars.container.get().id, get_content_path(context), context.__uuid__, uuid.uuid4().hex
+    )

--- a/guillotina/files/utils.py
+++ b/guillotina/files/utils.py
@@ -1,7 +1,6 @@
 from .const import MAX_REQUEST_CACHE_SIZE
 from guillotina import task_vars
 from guillotina.exceptions import UnRetryableRequestError
-from guillotina.utils import get_content_path
 from guillotina.utils import to_str
 
 import asyncio

--- a/guillotina/interfaces/__init__.py
+++ b/guillotina/interfaces/__init__.py
@@ -81,6 +81,7 @@ from .files import IFile  # noqa
 from .files import IFileCleanup  # noqa
 from .files import IFileField  # noqa
 from .files import IFileManager  # noqa
+from .files import IFileNameGenerator  # noqa
 from .files import IFileStorageManager  # noqa
 from .files import IUploadDataManager  # noqa
 from .json import IFactorySerializeToJson  # noqa

--- a/guillotina/interfaces/files.py
+++ b/guillotina/interfaces/files.py
@@ -158,6 +158,12 @@ class IFileCleanup(Interface):
         """
 
 
+class IFileNameGenerator(Interface):
+    """
+    Name generator for a file
+    """
+
+
 class IFile(Interface):
 
     content_type = schema.TextLine(

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -6,6 +6,7 @@ from guillotina.async_util import IAsyncUtility
 from guillotina.behaviors.instance import AnnotationBehavior
 from guillotina.behaviors.instance import ContextBehavior
 from guillotina.behaviors.properties import ContextProperty
+from guillotina.component import get_multi_adapter
 from guillotina.content import Item
 from guillotina.content import Resource
 from guillotina.directives import index_field
@@ -17,12 +18,12 @@ from guillotina.exceptions import NoIndexField
 from guillotina.fields import CloudFileField
 from guillotina.files import BaseCloudFile
 from guillotina.files.exceptions import RangeNotFound
-from guillotina.files.utils import generate_key
 from guillotina.interfaces import IApplication
 from guillotina.interfaces import IContainer
 from guillotina.interfaces import IExternalFileStorageManager
 from guillotina.interfaces import IFile
 from guillotina.interfaces import IFileField
+from guillotina.interfaces import IFileNameGenerator
 from guillotina.interfaces import IIDGenerator
 from guillotina.interfaces import IItem
 from guillotina.interfaces import IJSONToValue
@@ -32,6 +33,7 @@ from guillotina.interfaces import IResource
 from guillotina.response import HTTPUnprocessableEntity
 from guillotina.schema import Object
 from guillotina.schema.interfaces import IContextAwareDefaultFactory
+from guillotina.utils import apply_coroutine
 from shutil import copyfile
 from typing import AsyncIterator
 from zope.interface import implementer
@@ -404,7 +406,8 @@ class InMemoryFileManager:
         if upload_file_id is not None:
             await self.delete_upload(upload_file_id)
 
-        upload_file_id = generate_key(self.context)
+        generator = get_multi_adapter((self.context, self.field), IFileNameGenerator)
+        upload_file_id = await apply_coroutine(generator)
         _tmp_files[upload_file_id] = tempfile.mkstemp()[1]
         await dm.update(_chunks=0, upload_file_id=upload_file_id)
 
@@ -452,7 +455,8 @@ class InMemoryFileManager:
 
     async def copy(self, to_storage_manager, to_dm):
         file = self.field.get(self.field.context or self.context)
-        new_uri = generate_key(self.context)
+        generator = get_multi_adapter((self.context, self.field), IFileNameGenerator)
+        new_uri = await apply_coroutine(generator)
         _tmp_files[new_uri] = _tmp_files[file.uri]
         _tmp_files[new_uri] = tempfile.mkstemp()[1]
         copyfile(_tmp_files[file.uri], _tmp_files[new_uri])


### PR DESCRIPTION
For GCould we can do something like this:
```python
@configure.adapter(for_=(IResource, IGCloudFileField), provides=IFileNameGenerator)
class GCloudFileNameGenerator():

    def __init__(self, context, field):
        self.context = context
        self.field = field

    def __call__(self):
        return self.context.__uuid__
```
close https://github.com/plone/guillotina/issues/862