### PR TITLE
mailer: import 'aiosmtplib' and 'html2text' lazily

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 6.0.8 (unreleased)
 ------------------
 
+- mailer: import 'aiosmtplib' and 'html2text' lazily
+  [masipcat]
+
 - settings: always convert 'pool_size' to int
   [masipcat]
 

--- a/guillotina/contrib/mailer/utility.py
+++ b/guillotina/contrib/mailer/utility.py
@@ -10,10 +10,8 @@ from guillotina.contrib.mailer.exceptions import NoEndpointDefinedException
 from guillotina.interfaces import IMailEndpoint
 from guillotina.interfaces import IMailer
 from guillotina.utils import get_random_string
-from html2text import html2text
 from zope.interface import implementer
 
-import aiosmtplib
 import asyncio
 import logging
 import socket
@@ -35,6 +33,8 @@ class SMTPMailEndpoint(object):
         self.settings = settings
 
     async def connect(self):
+        import aiosmtplib
+
         try:
             self.conn = aiosmtplib.SMTP(self.settings["host"], self.settings["port"])
             await self.conn.connect()
@@ -127,6 +127,8 @@ class MailerUtility:
 
     def build_message(self, message, text=None, html=None):
         if not text and html and self.settings.get("use_html2text", True):
+            from html2text import html2text
+
             try:
                 text = html2text(html)
             except Exception:

--- a/guillotina/contrib/mailer/utility.py
+++ b/guillotina/contrib/mailer/utility.py
@@ -17,6 +17,7 @@ import logging
 import socket
 import time
 
+
 try:
     import aiosmtplib
 except ImportError:

--- a/guillotina/contrib/mailer/utility.py
+++ b/guillotina/contrib/mailer/utility.py
@@ -17,6 +17,17 @@ import logging
 import socket
 import time
 
+try:
+    import aiosmtplib
+except ImportError:
+    pass
+
+
+try:
+    from html2text import html2text
+except ImportError:
+    pass
+
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +44,6 @@ class SMTPMailEndpoint(object):
         self.settings = settings
 
     async def connect(self):
-        import aiosmtplib
-
         try:
             self.conn = aiosmtplib.SMTP(self.settings["host"], self.settings["port"])
             await self.conn.connect()
@@ -127,8 +136,6 @@ class MailerUtility:
 
     def build_message(self, message, text=None, html=None):
         if not text and html and self.settings.get("use_html2text", True):
-            from html2text import html2text
-
             try:
                 text = html2text(html)
             except Exception:


### PR DESCRIPTION
I'm using a custom MailerEndpoint based on aiobotocore so I don't need the aiosmtp and I don't use the html2text as well