### PR TITLE
More metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.51 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Record metrics on time waiting for pg locks
+  [vangheem]
 
 
 5.3.50 (2020-09-23)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 5.3.51 (unreleased)
 -------------------
 
+- Record metrics on cache hit/misses
+  [vangheem]
+
 - Record metrics on time waiting for pg locks
   [vangheem]
 

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -59,10 +59,9 @@ try:
     def record_cache_metric(
         name: str, result_type: str, value: Union[ObjectResultType, str], key_args: Dict[str, Any]
     ) -> None:
-        if isinstance(value, str):
-            if value == _EMPTY:
-                result_type += "_empty"
-        elif (
+        if value == _EMPTY:
+            result_type += "_empty"
+        elif isinstance(value, dict) and (
             value["zoid"] == ROOT_ID
             or value.get("parent_id") == ROOT_ID
             or isinstance(key_args.get("container"), (Container, Registry, Root))

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -26,6 +26,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 from typing_extensions import TypedDict
 from zope.interface import implementer
 
@@ -33,6 +34,9 @@ import asyncio
 import logging
 import sys
 import time
+
+
+_EMPTY = "__<EMPTY VALUE>__"
 
 
 class ObjectResultType(TypedDict, total=False):
@@ -53,9 +57,12 @@ try:
     )
 
     def record_cache_metric(
-        name: str, result_type: str, value: ObjectResultType, key_args: Dict[str, Any]
+        name: str, result_type: str, value: Union[ObjectResultType, str], key_args: Dict[str, Any]
     ) -> None:
-        if (
+        if isinstance(value, str):
+            if value == _EMPTY:
+                result_type += "_empty"
+        elif (
             value["zoid"] == ROOT_ID
             or value.get("parent_id") == ROOT_ID
             or isinstance(key_args.get("container"), (Container, Registry, Root))
@@ -68,12 +75,9 @@ try:
 except ImportError:
 
     def record_cache_metric(
-        name: str, result_type: str, value: ObjectResultType, key_args: Dict[str, Any]
+        name: str, result_type: str, value: Union[ObjectResultType, str], key_args: Dict[str, Any]
     ) -> None:
         ...
-
-
-_EMPTY = "__<EMPTY VALUE>__"
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
- Record metrics on time waiting for pg locks: will help us understand how much shared connection is affecting us.
- Record hit/miss metrics on cache implementation: help us measure in-memory cache performance of root/container vs non-root objects