### PR TITLE
Safer keys for memcached

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 5.3.58 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Safer keys for memcached driver [lferran]
 
 
 5.3.57 (2020-10-14)

--- a/guillotina/contrib/memcached/driver.py
+++ b/guillotina/contrib/memcached/driver.py
@@ -89,7 +89,7 @@ try:
                 counter=MEMCACHED_OPS,
                 histogram=MEMCACHED_OPS_PROCESSING_TIME,
                 labels={"type": operation},
-                error_mappings={"timeout": asyncio.TimeoutError},
+                error_mappings={"timeout": asyncio.TimeoutError, "cancelled": asyncio.CancelledError},
             )
 
 

--- a/guillotina/contrib/memcached/driver.py
+++ b/guillotina/contrib/memcached/driver.py
@@ -15,6 +15,7 @@ from typing import Optional
 import asyncio
 import backoff
 import copy
+import hashlib
 import logging
 
 
@@ -100,6 +101,14 @@ except ImportError:
 logger = logging.getLogger("guillotina.contrib.memcached")
 
 
+def safe_key(key: str) -> bytes:
+    """This is needed because memcached servers do not support keys longer
+    than 250 bytes, or keys with control characters or whitespaces.
+
+    """
+    return hashlib.sha224(key.encode()).hexdigest().encode()
+
+
 class MemcachedDriver:
     """
     Implements a cache driver using Memcached
@@ -182,12 +191,12 @@ class MemcachedDriver:
         if expire is not None:
             kwargs["exptime"] = expire
         with watch("set"):
-            await client.set(key.encode(), data, **kwargs)
+            await client.set(safe_key(key), data, **kwargs)
 
     async def get(self, key: str) -> Optional[bytes]:
         client = self._get_client()
         with watch("get") as w:
-            item: Optional[emcache.Item] = await client.get(key.encode())
+            item: Optional[emcache.Item] = await client.get(safe_key(key))
             if item is None:
                 # cache miss
                 w.labels["type"] = "get_miss"
@@ -199,7 +208,7 @@ class MemcachedDriver:
     async def delete(self, key: str) -> None:
         client = self._get_client()
         with watch("delete"):
-            await client.delete(key.encode(), noreply=True)
+            await client.delete(safe_key(key), noreply=True)
 
     async def delete_all(self, keys: List[str]) -> None:
         client = self._get_client()
@@ -207,7 +216,7 @@ class MemcachedDriver:
             for key in keys:
                 try:
                     with watch("delete"):
-                        await client.delete(key.encode(), noreply=True)
+                        await client.delete(safe_key(key), noreply=True)
                     logger.debug("Deleted cache keys {}".format(keys))
                 except Exception:
                     logger.warning("Error deleting cache keys {}".format(keys), exc_info=True)

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -104,5 +104,5 @@ async def test_memcached_ops(memcached_container, guillotina_main, loop):
 @pytest.mark.app_settings(MEMCACHED_SETTINGS)
 async def test_safe_key(memcached_container, guillotina_main, loop):
     driver = await resolve_dotted_name("guillotina.contrib.memcached").get_driver()
-    for unsafe_key in ["a" * 255, "foo bar", "&a"]:
+    for unsafe_key in ["a" * 255, "foo bar", "&a", b"\x130".decode()]:
         await driver.get(unsafe_key)

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -1,5 +1,4 @@
 from guillotina.contrib.memcached.driver import MemcachedDriver
-from guillotina.contrib.memcached.driver import safe_key
 from guillotina.utils import resolve_dotted_name
 from unittest import mock
 

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -1,4 +1,5 @@
 from guillotina.contrib.memcached.driver import MemcachedDriver
+from guillotina.contrib.memcached.driver import safe_key
 from guillotina.utils import resolve_dotted_name
 from unittest import mock
 
@@ -99,3 +100,10 @@ async def test_memcached_ops(memcached_container, guillotina_main, loop):
 
     await driver.finalize()
     assert driver.initialized is False
+
+
+@pytest.mark.app_settings(MEMCACHED_SETTINGS)
+async def test_safe_key(memcached_container, guillotina_main, loop):
+    driver = await resolve_dotted_name("guillotina.contrib.memcached").get_driver()
+    for unsafe_key in ["a" * 255, "foo bar", "&a"]:
+        await driver.get(unsafe_key)


### PR DESCRIPTION
## What this PR does

Hashes cache keys before sending it to memcached, to avoid having keys that aren't valid.

Pros:
 - right now, keys include db_id, and possibly the uuid of the object + container_id. The length of the key is not bounded right now. This PR fixes it in a simple way.

Cons:
 - Adds a little bit of extra cpu
 - Hashing the whole key could introduce cross-container collisions, but the probability is very low. Assuming a cache of 10Gi: 

```
prob_key_collision = 1.0 / 15**56
n_cache_keys = 10 * 2**30

prob_key_collision * n_cache_keys = ~ 1.5e-56
```


