### PR TITLE
Improve delete all for the memcache driver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.61 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do nothing when memcache delete_all opeartion receives an empty list. Observe
+  size of the len of keys [pfreixes]
 
 
 5.3.60 (2020-11-03)

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -134,7 +134,7 @@ async def test_delete_all():
             watch_mocked.assert_called()
             all_keys.observe.assert_called_with(2)
             driver._client.delete.assert_has_calls(
-                [mock.call(safe_key("foo"), noreply=True), mock.call(safe_key("bar"), noreply=True),]
+                [mock.call(safe_key("foo"), noreply=True), mock.call(safe_key("bar"), noreply=True)]
             )
 
 

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -140,7 +140,9 @@ async def test_delete_all():
 
 async def test_delete_all_empty_keys():
     with mock.patch("guillotina.contrib.memcached.driver.watch") as watch_mocked:
-        driver = MemcachedDriver()
-        driver._client = mock.Mock()
-        await driver.delete_all([])
-        watch_mocked.assert_not_called()
+        with mock.patch("guillotina.contrib.memcached.driver.MEMCACHED_OPS_DELETE_ALL_NUM_KEYS") as all_keys:
+            driver = MemcachedDriver()
+            driver._client = mock.Mock()
+            await driver.delete_all([])
+            all_keys.observe.assert_not_called()
+            watch_mocked.assert_not_called()

--- a/guillotina/tests/memcached/test_metrics.py
+++ b/guillotina/tests/memcached/test_metrics.py
@@ -118,3 +118,4 @@ class TestMemcachedMetrics:
             )
             > 0
         )
+        assert metrics_registry.get_sample_value("guillotina_cache_memcached_delete_all_num_keys_sum") > 0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             "pytest-asyncio==0.10.0",
             "pytest-cov>=2.0.0,<=2.9.0",
             "coverage>=4.0.3",
-            "pytest-docker-fixtures",
+            "pytest-docker-fixtures==1.3.11",
             "pytest-rerunfailures<10.0.0",
             "openapi-spec-validator",
             "asyncmock",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             "pytest-asyncio==0.10.0",
             "pytest-cov>=2.0.0,<=2.9.0",
             "coverage>=4.0.3",
-            "pytest-docker-fixtures==1.3.11",
+            "pytest-docker-fixtures>=1.3.11",
             "pytest-rerunfailures<10.0.0",
             "openapi-spec-validator",
             "asyncmock",


### PR DESCRIPTION
- Do not execute internally the delete all when len of the keys is 0
- Observe, if metrics available, the size of the list of keys