### PR TITLE
[5.x] Fix not recording pg root metrics properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.62 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix recording root hit/miss metrics
+  [vangheem]
 
 
 5.3.61 (2020-11-11)

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -31,6 +31,7 @@ from typing_extensions import TypedDict
 from zope.interface import implementer
 
 import asyncio
+import asyncpg
 import logging
 import sys
 import time
@@ -61,7 +62,7 @@ try:
     ) -> None:
         if value == _EMPTY:
             result_type += "_empty"
-        elif isinstance(value, dict) and (
+        elif isinstance(value, (dict, asyncpg.Record)) and (
             value["zoid"] == ROOT_ID
             or value.get("parent_id") == ROOT_ID
             or isinstance(key_args.get("container"), (Container, Registry, Root))
@@ -359,6 +360,7 @@ class Transaction:
         additional_keys=[lambda item: {"container": item["parent_id"], "id": item["id"]}],
     )
     async def _get(self, oid):
+        print("loading")
         return await self._manager._storage.load(self, oid)
 
     @profilable

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -360,7 +360,6 @@ class Transaction:
         additional_keys=[lambda item: {"container": item["parent_id"], "id": item["id"]}],
     )
     async def _get(self, oid):
-        print("loading")
         return await self._manager._storage.load(self, oid)
 
     @profilable


### PR DESCRIPTION
Objects that come from an external cache system are `dict` type; however, objects that are from in-memory and misses are `asyncpg.Record` type.