### PR TITLE
Abort transaction if tpc_commit() crashes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.0.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Abort transaction if tpc_commit() crashes
+  [masipcat]
 
 
 6.0.15 (2020-11-25)

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -363,6 +363,10 @@ class Transaction:
             await self._cache.close(invalidate=isinstance(ex, TIDConflictError), publish=False)
             self.tpc_cleanup()
             raise
+        except Exception:
+            await self.abort()
+            raise
+
         self.status = Status.COMMITTED
         await self._call_after_commit_hooks()
 


### PR DESCRIPTION
I found this while implementing a PoC of JSON Storage and some objects crashed during serialization