### PR TITLE
Use orjson 3.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 -------------------
 - Update gmi
 
+- Update orjson to 3.x
+  [waghanza]
+
 
 6.0.18 (2020-12-05)
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ PyJWT==1.6.0
 python-dateutil==2.6.1
 PyYaml>=5.1
 six==1.11.0
-orjson==2.6.0
+orjson>=3,<4
 zope.interface==5.1.0
 uvicorn==0.10.8
 argon2-cffi==18.3.0

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "pycryptodome",
         "jwcrypto",
         "setuptools",
-        "orjson==2.6.0",
+        "orjson>=3,<4",
         "zope.interface",
         "pyjwt",
         "asyncpg",


### PR DESCRIPTION
Hi,

As `orjson` 3.x has many fixes, see https://github.com/ijl/orjson/releases, I can suggest to use this version instead of **2.6.0**

Besides, it will fix https://github.com/the-benchmarker/web-frameworks/pull/3600

Regards,

-----------
ℹ️  This is a redo of #1062 