### PR TITLE
Emcache bump, support for Min connections and new metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.64 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bump emcache version and provide support for new metrics and new intialization parameters
+  [pfreixes]
 
 
 5.3.63 (2020-11-30)

--- a/contrib-requirements.txt
+++ b/contrib-requirements.txt
@@ -9,5 +9,5 @@ mypy==0.720
 mypy-zope==0.2.0
 black==19.10b0
 isort==4.3.21
-emcache==0.3.0b0
+emcache==0.4.1
 pymemcache==3.4.0


### PR DESCRIPTION
Bump to the last stable release for emcache which provides support for the following

- A new init parameter for telling the minimum number of TCP connections that must keep open
- A new set of metrics for knowing the latencies for creating new connections