### PR TITLE
docs(index) adjust markup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve markup (docs/index.md)
+  [svx]
 
 
 6.1.0 (2021-01-11)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,7 +12,7 @@ pip install guillotina
 g serve --port=8080
 ```
 
-Then use curl, [Postman](https://www.postman.com/ "Link to Postman") or build something with it::
+Then use curl, [Postman](https://www.postman.com/ "Link to Postman") or build something with it:
 
 ```shell
 curl -XPOST --user root:root http://localhost:8080/db -d '{


### PR DESCRIPTION
This PR:
- Adjust markup of /docs/index.md (remove `rst` syntax, since it is Markdown)  