### PR TITLE
Fix: prevent caching objects bigger than max_cache_record_size 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 5.3.66 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix: prevent caching large objects on fill_cache [lferran]
 
 
 5.3.65 (2021-01-11)

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -81,8 +81,7 @@ class BasicCache(BaseCache):
     async def store_object(self, obj, pickled):
         if len(pickled) > self.max_cache_record_size:
             # Do not store objects that exceed the record size
-            # return
-            pass
+            return
 
         if len(self._stored_objects) < self.max_publish_objects:
             self._stored_objects.append((obj, pickled))

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -79,6 +79,10 @@ class BasicCache(BaseCache):
         await self._utility.delete_all(keys)
 
     async def store_object(self, obj, pickled):
+        if len(pickled) > self.max_cache_record_size:
+            # Do not store objects that exceed the record size
+            return
+
         if len(self._stored_objects) < self.max_publish_objects:
             self._stored_objects.append((obj, pickled))
             # also assume these objects are then stored

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -81,7 +81,8 @@ class BasicCache(BaseCache):
     async def store_object(self, obj, pickled):
         if len(pickled) > self.max_cache_record_size:
             # Do not store objects that exceed the record size
-            return
+            # return
+            pass
 
         if len(self._stored_objects) < self.max_publish_objects:
             self._stored_objects.append((obj, pickled))

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -117,7 +117,6 @@ class cache:
             result = await func(self, *args, **kwargs)
 
             record_cache_metric(func.__name__, "miss", result, key_args)
-
             if result is not None:
                 if result == _EMPTY:
                     await self._cache.set(result, keyset=[key_args])
@@ -454,6 +453,7 @@ class Transaction:
     @profilable
     async def tpc_commit(self):
         """Commit changes to an object"""
+
         await self._strategy.tpc_commit()
         for oid, obj in self.deleted.items():
             await self._manager._storage.delete(self, oid)

--- a/guillotina/tests/cache/test_cache_memory.py
+++ b/guillotina/tests/cache/test_cache_memory.py
@@ -4,7 +4,11 @@ from guillotina.db.transaction import Transaction
 from guillotina.interfaces import ICacheUtility
 from guillotina.tests import mocks
 from guillotina.tests.utils import create_content
+from unittest import mock
+from unittest.mock import MagicMock
+from unittest.mock import Mock
 
+import asyncio
 import pytest
 
 
@@ -137,3 +141,42 @@ async def test_do_not_cache_large_object(guillotina_main, loop):
     loaded = await txn.get(ob.__uuid__)
     assert id(loaded) != id(ob)
     assert loaded.__uuid__ == ob.__uuid__
+
+
+@pytest.fixture(scope="function")
+def mocked_cache_set(loop):
+    with mock.patch("guillotina.contrib.cache.strategy.BasicCache.set") as mock_set:
+        f = asyncio.Future()
+        f.set_result(None)
+        mock_set.return_value = f
+        yield mock_set
+
+
+@pytest.mark.app_settings(DEFAULT_SETTINGS)
+async def test_fill_cache_doesnt_cache_large_objects(guillotina_main, loop, mocked_cache_set):
+    tm = mocks.MockTransactionManager()
+    txn = Transaction(tm)
+    cache = BasicCache(txn)
+
+    # Mock storing an object that is over the limit
+    obj = Mock()
+    obj.__uuid__ = "foo"
+    obj.__serial__ = "bar"
+    obj.__name__ = "ba"
+    obj.__of__ = "bi"
+
+    pickled = MagicMock()
+    pickled.__len__.return_value = BasicCache.max_cache_record_size + 10
+
+    await cache.store_object(obj, pickled)
+
+    # Call fill_cache and check that caching was skipped
+    await cache.fill_cache()
+
+    cache.set.assert_not_called()
+
+    # Now add smaller object and check that is cached
+    pickled.__len__.return_value = 1
+    await cache.store_object(obj, pickled)
+    await cache.fill_cache()
+    cache.set.assert_called_once()


### PR DESCRIPTION
Seems that we are checking this restriction [during the transaction](https://github.com/plone/guillotina/blob/5.x/guillotina/db/transaction.py#L128), but not when syncronizing through the pubsub [at transaction close time](https://github.com/plone/guillotina/blob/5.x/guillotina/contrib/cache/strategy.py#L144). 

Therefore, we are storing in memory and sending to redis/memcached objects that are over the size limit.

Not 100% sure if that's the best way to fix it though, as it could also be done in `BasicCache.fill_cache`.


Once this is correctly fix, I will port to `master`