### PR TITLE
docs(developer) adjust and unify wording

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ CHANGELOG
 - Various documentation improvements
   [svx]
 
+- Unify wording in dev docs
+  [svx]
+
 
 6.1.0 (2021-01-11)
 ------------------

--- a/docs/source/developer/contenttypes.md
+++ b/docs/source/developer/contenttypes.md
@@ -34,7 +34,7 @@ class MyType(Folder):
     pass
 ```
 
-This example creates a simple schema and assigns it to the `MyType` content
+This example creates a schema and assigns it to the `MyType` content
 type.
 
 

--- a/docs/source/developer/debugging.md
+++ b/docs/source/developer/debugging.md
@@ -67,5 +67,5 @@ python -m aiomonitor.cli
 ## Jupyter
 
 Guillotina also works with Jupyter notebooks. Load the
-[example notebook](https://github.com/plone/guillotina/blob/master/guillotina.ipynb) in the guillotina
+[example notebook](https://github.com/plone/guillotina/blob/master/guillotina.ipynb) in the Guillotina
 repository to see an example of how to get started.

--- a/docs/source/developer/design.md
+++ b/docs/source/developer/design.md
@@ -1,11 +1,11 @@
 # Design
 
-This section is meant to explain and defend the design of `guillotina`.
+This section is meant to explain and defend the design of Guillotina.
 
 
 ## JavaScript application development focus
 
-One of the main driving factors behind the development of `guillotina` is to
+One of the main driving factors behind the development of Guillotina is to
 streamline the development of custom web applications.
 
 Some of the technologies we support in order to be a great web application development
@@ -19,7 +19,7 @@ platform are:
 
 ## Speed
 
-A primary focus of `guillotina` is speed. We take shortcuts and may use some
+A primary focus of Guillotina is speed. We take shortcuts and may use some
 ugly or less-well conceptually architected solutions in some areas in order
 to gain speed improvements.
 
@@ -28,7 +28,7 @@ Mainly, we try to stay light on the amount of data we're loading from the
 database where possible and we try to lower the number of lookups we do in
 certain scenarios.
 
-That being said, `guillotina` is not a barebones framework. It provides a lot
+That being said, Guillotina is not a barebones framework. It provides a lot
 of functionality so it will never be as fast as say Pyramid.
 
 "There are no solutions. There are only trade-offs." - Thomas Sowell
@@ -36,22 +36,22 @@ of functionality so it will never be as fast as say Pyramid.
 
 ## Asynchronous
 
-`guillotina` is asynchronous from the ground up, built with `asgi`
+Guillotina is asynchronous from the ground up, built with ASGI
 using Python 3.7's asyncio features.
 
 Practically speaking, being built completely on asyncio compatible technologies,
-`guillotina` does not block for network IO to the database, index catalog,
+Guillotina does not block for network IO to the database, index catalog,
 redis, etc or whatever you've integrated.
 
 Additionally, we have support for async utilities that run in the same async
 loop and async content events.
 
-Finally, we also support web sockets OOTB.
+Finally, we also support web sockets OOTB (Out Of The Box).
 
 
 ## Security
 
-`Guillotina` uses the same great security infrastructure that Plone
+Guillotina uses the same great security infrastructure that Plone
 has been using for the last 15 years which allows you to define permissions, roles,
 groups, users and customize all of them contextually based on where the content
 is located in your container.
@@ -59,7 +59,7 @@ is located in your container.
 
 ## Style
 
-Stylistically, `guillotina` pulls ideas from the best web frameworks:
+Stylistically, Guillotina pulls ideas from the best web frameworks:
 
 - YAML/JSON configuration
 - Pyramid-like idioms and syntax where it makes sense

--- a/docs/source/developer/interfaces.md
+++ b/docs/source/developer/interfaces.md
@@ -1,12 +1,12 @@
 # Interfaces
 
-`guillotina` uses interfaces to abstract and define various things including
+Guillotina uses interfaces to abstract and define various things including
 content. Interfaces are useful when defining API contracts, using inheritance,
 defining schema/behaviors and being able to define which content your services
 are used for.
 
 In the services example, you'll notice the use of `context=IContainer` for the service
-decorator configuration. In that case, it is used to tell `guillotina` that the
+decorator configuration. In that case, it is used to tell Guillotina that the
 service is only defined for a container object.
 
 Read the [zope.interface documentation](https://zopeinterface.readthedocs.io/en/latest/)

--- a/docs/source/developer/persistence.md
+++ b/docs/source/developer/persistence.md
@@ -16,7 +16,7 @@ There are three kinds of objects that are considered on the system:
 
 If you're manually modifying objects in services(or views) without using
 the serialization adapters, you need to register the object to be saved
-to the database. To do this, just use the `register()` method.
+to the database. To do this, use the `register()` method.
 
 
 ```python


### PR DESCRIPTION
This PR:

- Unify wording (remove command syntax and use proper name)
- Explain OOTB
- Remove "just" and "simple"