### PR TITLE
forward-port fix: prevent caching objects bigger than max_cache_record_size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 6.1.1 (unreleased)
 ------------------
 
+- Fix: prevent caching large objects on fill_cache [lferran]
+
 - Improve markup (docs/index.md)
   [svx]
 

--- a/guillotina/contrib/cache/strategy.py
+++ b/guillotina/contrib/cache/strategy.py
@@ -79,6 +79,10 @@ class BasicCache(BaseCache):
         await self._utility.delete_all(keys)
 
     async def store_object(self, obj, pickled):
+        if len(pickled) > self.max_cache_record_size:
+            # Do not store objects that exceed the record size
+            return
+
         if len(self._stored_objects) < self.max_publish_objects:
             self._stored_objects.append((obj, pickled))
             # also assume these objects are then stored

--- a/guillotina/db/transaction.py
+++ b/guillotina/db/transaction.py
@@ -116,7 +116,6 @@ class cache:
             result = await func(self, *args, **kwargs)
 
             record_cache_metric(func.__name__, "miss", result, key_args)
-
             if result is not None:
                 if result == _EMPTY:
                     await self._cache.set(result, keyset=[key_args])
@@ -144,7 +143,12 @@ class Transaction:
     user = None
 
     def __init__(
-        self, manager, loop=None, read_only: bool = False, cache=None, strategy=None,
+        self,
+        manager,
+        loop=None,
+        read_only: bool = False,
+        cache=None,
+        strategy=None,
     ):
         # Transaction Manager
         self._manager = manager
@@ -164,7 +168,10 @@ class Transaction:
         self._lock = asyncio.Lock(loop=loop)
 
     def initialize(
-        self, read_only, cache=None, strategy=None,
+        self,
+        read_only,
+        cache=None,
+        strategy=None,
     ):
         self._read_only = read_only
         self._txn_time = None
@@ -229,26 +236,22 @@ class Transaction:
         return self._manager._storage
 
     def get_before_commit_hooks(self):
-        """ See ITransaction.
-        """
+        """See ITransaction."""
         return iter(self._before_commit)
 
     def add_before_commit_hook(self, hook, *real_args, args=None, kws=None, **kwargs):
-        """ See ITransaction.
-        """
+        """See ITransaction."""
         args = args or []
         kws = kws or {}
         kwargs.update(kws)
         self._before_commit.append((hook, real_args + tuple(args), kwargs))
 
     def get_after_commit_hooks(self):
-        """ See ITransaction.
-        """
+        """See ITransaction."""
         return iter(self._after_commit)
 
     def add_after_commit_hook(self, hook, *real_args, args=None, kws=None, **kwargs):
-        """ See ITransaction.
-        """
+        """See ITransaction."""
         args = args or []
         kws = kws or {}
         kwargs.update(kws)
@@ -457,6 +460,7 @@ class Transaction:
     @profilable
     async def tpc_commit(self):
         """Commit changes to an object"""
+
         await self._strategy.tpc_commit()
         for oid, obj in self.added.items():
             await self._store_object(obj, oid, True)
@@ -475,8 +479,7 @@ class Transaction:
 
     @profilable
     async def tpc_finish(self):
-        """Indicate confirmation that the transaction is done.
-        """
+        """Indicate confirmation that the transaction is done."""
         await self._strategy.tpc_finish()
         await self._cache.close()
         self.tpc_cleanup()

--- a/guillotina/tests/cache/test_cache_memory.py
+++ b/guillotina/tests/cache/test_cache_memory.py
@@ -4,7 +4,11 @@ from guillotina.db.transaction import Transaction
 from guillotina.interfaces import ICacheUtility
 from guillotina.tests import mocks
 from guillotina.tests.utils import create_content
+from unittest import mock
+from unittest.mock import MagicMock
+from unittest.mock import Mock
 
+import asyncio
 import pytest
 
 
@@ -140,3 +144,42 @@ async def test_do_not_cache_large_object(guillotina_main):
     loaded = await txn.get(ob.__uuid__)
     assert id(loaded) != id(ob)
     assert loaded.__uuid__ == ob.__uuid__
+
+
+@pytest.fixture(scope="function")
+def mocked_cache_set(loop):
+    with mock.patch("guillotina.contrib.cache.strategy.BasicCache.set") as mock_set:
+        f = asyncio.Future()
+        f.set_result(None)
+        mock_set.return_value = f
+        yield mock_set
+
+
+@pytest.mark.app_settings(DEFAULT_SETTINGS)
+async def test_fill_cache_doesnt_cache_large_objects(guillotina_main, loop, mocked_cache_set):
+    tm = mocks.MockTransactionManager()
+    txn = Transaction(tm)
+    cache = BasicCache(txn)
+
+    # Mock storing an object that is over the limit
+    obj = Mock()
+    obj.__uuid__ = "foo"
+    obj.__serial__ = "bar"
+    obj.__name__ = "ba"
+    obj.__of__ = "bi"
+
+    pickled = MagicMock()
+    pickled.__len__.return_value = BasicCache.max_cache_record_size + 10
+
+    await cache.store_object(obj, pickled)
+
+    # Call fill_cache and check that caching was skipped
+    await cache.fill_cache()
+
+    cache.set.assert_not_called()
+
+    # Now add smaller object and check that is cached
+    pickled.__len__.return_value = 1
+    await cache.store_object(obj, pickled)
+    await cache.fill_cache()
+    cache.set.assert_called_once()


### PR DESCRIPTION
Original PR on 5.x branch: https://github.com/plone/guillotina/pull/1085