### PR TITLE
add max_content_depth limit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,7 @@ CHANGELOG
 5.3.67 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Add max_content_depth [lferran]
 
 5.3.66 (2021-01-13)
 -------------------

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -18,7 +18,6 @@ from guillotina.directives import merged_tagged_value_dict
 from guillotina.directives import read_permission
 from guillotina.event import notify
 from guillotina.events import BeforeObjectModifiedEvent
-from guillotina.exceptions import MaxDepthReached
 from guillotina.events import BeforeObjectRemovedEvent
 from guillotina.events import ObjectAddedEvent
 from guillotina.events import ObjectModifiedEvent
@@ -26,6 +25,7 @@ from guillotina.events import ObjectPermissionsViewEvent
 from guillotina.events import ObjectRemovedEvent
 from guillotina.events import ObjectVisitedEvent
 from guillotina.exceptions import ComponentLookupError
+from guillotina.exceptions import MaxDepthReached
 from guillotina.exceptions import PreconditionFailed
 from guillotina.i18n import default_message_factory as _
 from guillotina.interfaces import IAnnotations
@@ -58,7 +58,6 @@ from guillotina.response import Response
 from guillotina.security.utils import apply_sharing
 from guillotina.transactions import get_transaction
 from guillotina.utils import get_authenticated_user_id
-from guillotina.utils import get_content_depth
 from guillotina.utils import get_behavior
 from guillotina.utils import get_object_by_uid
 from guillotina.utils import get_object_url
@@ -196,11 +195,6 @@ class DefaultPOST(Service):
                     reason=error_reasons.INVALID_ID,
                 )
             new_id = id_
-
-        # Restrict object tree height
-        max_depth = app_settings.get("max_content_depth", None)
-        if max_depth is not None and get_content_depth(self.context) > max_depth:
-            raise MaxDepthReached()
 
         user = get_authenticated_user_id()
 

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -25,7 +25,6 @@ from guillotina.events import ObjectPermissionsViewEvent
 from guillotina.events import ObjectRemovedEvent
 from guillotina.events import ObjectVisitedEvent
 from guillotina.exceptions import ComponentLookupError
-from guillotina.exceptions import MaxDepthReached
 from guillotina.exceptions import PreconditionFailed
 from guillotina.i18n import default_message_factory as _
 from guillotina.interfaces import IAnnotations

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -197,6 +197,7 @@ class DefaultPOST(Service):
                 )
             new_id = id_
 
+        # Restrict object tree height
         max_depth = app_settings.get("max_content_depth", None)
         if max_depth is not None and get_content_depth(self.context) > max_depth:
             raise MaxDepthReached()

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -18,6 +18,7 @@ from guillotina.directives import merged_tagged_value_dict
 from guillotina.directives import read_permission
 from guillotina.event import notify
 from guillotina.events import BeforeObjectModifiedEvent
+from guillotina.exceptions import MaxDepthReached
 from guillotina.events import BeforeObjectRemovedEvent
 from guillotina.events import ObjectAddedEvent
 from guillotina.events import ObjectModifiedEvent
@@ -57,6 +58,7 @@ from guillotina.response import Response
 from guillotina.security.utils import apply_sharing
 from guillotina.transactions import get_transaction
 from guillotina.utils import get_authenticated_user_id
+from guillotina.utils import get_content_depth
 from guillotina.utils import get_behavior
 from guillotina.utils import get_object_by_uid
 from guillotina.utils import get_object_url
@@ -194,6 +196,10 @@ class DefaultPOST(Service):
                     reason=error_reasons.INVALID_ID,
                 )
             new_id = id_
+
+        max_depth = app_settings.get("max_content_depth", None)
+        if max_depth is not None and get_content_depth(self.context) > max_depth:
+            raise MaxDepthReached()
 
         user = get_authenticated_user_id()
 

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -59,6 +59,7 @@ from guillotina.response import HTTPConflict
 from guillotina.schema.utils import get_default_from_schema
 from guillotina.security.security_code import PrincipalPermissionManager
 from guillotina.transactions import get_transaction
+from guillotina.utils import get_content_depth
 from guillotina.utils import get_object_by_uid
 from guillotina.utils import get_security_policy
 from guillotina.utils import navigate_to
@@ -174,8 +175,7 @@ class Resource(guillotina.db.orm.base.BaseObject):
         super(Resource, self).__init__()
 
     def __repr__(self):
-        """
-        """
+        """"""
         path = "/".join(get_physical_path(self))
         return "< {type} at {path} by {mem} >".format(type=self.type_name, path=path, mem=id(self))
 
@@ -389,8 +389,7 @@ class Folder(Resource):
 
 @configure.contenttype(type_name="Container", schema=IContainer)
 class Container(Folder):
-    """
-    """
+    """"""
 
     async def install(self):
         # Creating and registering a local registry
@@ -601,6 +600,11 @@ async def create_content_in_container(
     if constrains is not None:
         if not constrains.is_type_allowed(type_):
             raise NotAllowedContentType(str(parent), type_)
+
+    # Restrict object tree height
+    max_depth = app_settings.get("max_content_depth", None)
+    if max_depth is not None and get_content_depth(parent) > max_depth:
+        raise MaxDepthReached(max_depth)
 
     # We create the object with at least the ID
     obj = factory(id=id_, parent=parent)

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -28,6 +28,7 @@ from guillotina.events import ObjectLoadedEvent
 from guillotina.events import ObjectMovedEvent
 from guillotina.exceptions import ConflictIdOnContainer
 from guillotina.exceptions import InvalidContentType
+from guillotina.exceptions import MaxDepthReached
 from guillotina.exceptions import NoPermissionToAdd
 from guillotina.exceptions import NotAllowedContentType
 from guillotina.exceptions import PreconditionFailed
@@ -604,7 +605,7 @@ async def create_content_in_container(
     # Restrict object tree height
     max_depth = app_settings.get("max_content_depth", None)
     if max_depth is not None and get_content_depth(parent) > max_depth:
-        raise MaxDepthReached(max_depth)
+        raise MaxDepthReached()
 
     # We create the object with at least the ID
     obj = factory(id=id_, parent=parent)

--- a/guillotina/exc_resp.py
+++ b/guillotina/exc_resp.py
@@ -3,11 +3,11 @@ from guillotina import error_reasons
 from guillotina.exceptions import ConflictIdOnContainer
 from guillotina.exceptions import DeserializationError
 from guillotina.exceptions import InvalidContentType
+from guillotina.exceptions import MaxDepthReached
 from guillotina.exceptions import NotAllowedContentType
 from guillotina.exceptions import PreconditionFailed
 from guillotina.exceptions import Unauthorized
 from guillotina.exceptions import UnRetryableRequestError
-from guillotina.exceptions import MaxDepthReached
 from guillotina.interfaces import IErrorResponseException
 from guillotina.response import HTTPConflict
 from guillotina.response import HTTPExpectationFailed
@@ -89,7 +89,5 @@ register_handler_factory(
 
 register_handler_factory(
     MaxDepthReached,
-    exception_handler_factory(
-        error_reasons.PRECONDITION_FAILED, "MaxDepthReached", serialize_exc=True
-    ),
+    exception_handler_factory(error_reasons.PRECONDITION_FAILED, "MaxDepthReached", serialize_exc=True),
 )

--- a/guillotina/exc_resp.py
+++ b/guillotina/exc_resp.py
@@ -7,6 +7,7 @@ from guillotina.exceptions import NotAllowedContentType
 from guillotina.exceptions import PreconditionFailed
 from guillotina.exceptions import Unauthorized
 from guillotina.exceptions import UnRetryableRequestError
+from guillotina.exceptions import MaxDepthReached
 from guillotina.interfaces import IErrorResponseException
 from guillotina.response import HTTPConflict
 from guillotina.response import HTTPExpectationFailed
@@ -83,5 +84,12 @@ register_handler_factory(
     Unauthorized,
     exception_handler_factory(
         error_reasons.UNAUTHORIZED, "Unauthorized", serialize_exc=True, klass=HTTPUnauthorized
+    ),
+)
+
+register_handler_factory(
+    MaxDepthReached,
+    exception_handler_factory(
+        error_reasons.PRECONDITION_FAILED, "MaxDepthReached", serialize_exc=True
     ),
 )

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -71,6 +71,7 @@ class UnRetryableRequestError(Exception):
 class MaxDepthReached(Exception):
     pass
 
+
 class PreconditionFailed(Exception):
     def __init__(self, container, precondition):
         super().__init__()
@@ -154,8 +155,7 @@ class RestartCommit(Exception):
 
 
 class ConfigurationError(Exception):
-    """There was an error in a configuration
-    """
+    """There was an error in a configuration"""
 
 
 class ServiceConfigurationError(ConfigurationError):
@@ -197,8 +197,7 @@ class BlobChunkNotFound(Exception):
 
 
 class DeserializationError(Exception):
-    """An error happened during deserialization of content.
-    """
+    """An error happened during deserialization of content."""
 
     def __init__(self, errors):
         super().__init__()
@@ -220,8 +219,7 @@ class DeserializationError(Exception):
 
 
 class ValueDeserializationError(Exception):
-    """An error happened during deserialization of content.
-    """
+    """An error happened during deserialization of content."""
 
     def __init__(self, field, value, msg):
         super().__init__()
@@ -231,8 +229,7 @@ class ValueDeserializationError(Exception):
 
 
 class QueryParsingError(Exception):
-    """An error happened while parsing a search query.
-    """
+    """An error happened while parsing a search query."""
 
 
 class FileNotFoundException(Exception):

--- a/guillotina/exceptions.py
+++ b/guillotina/exceptions.py
@@ -68,6 +68,9 @@ class UnRetryableRequestError(Exception):
     pass
 
 
+class MaxDepthReached(Exception):
+    pass
+
 class PreconditionFailed(Exception):
     def __init__(self, container, precondition):
         super().__init__()

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -1511,11 +1511,17 @@ async def test_default_post_and_patch_handles_wrong_json_payload(container_reque
 @pytest.mark.app_settings({"max_content_depth": 2})
 async def test_max_depth_on_post(container_requester):
     async with container_requester as requester:
-        _, status = await requester("POST", "/db/guillotina/", data=json.dumps({"@type": "Folder", "id": "foo"}))
+        _, status = await requester(
+            "POST", "/db/guillotina/", data=json.dumps({"@type": "Folder", "id": "foo"})
+        )
         assert status == 201
-        _, status = await requester("POST", "/db/guillotina/foo", data=json.dumps({"@type": "Folder", "id": "foo"}))
+        _, status = await requester(
+            "POST", "/db/guillotina/foo", data=json.dumps({"@type": "Folder", "id": "foo"})
+        )
         assert status == 201
-        resp, status = await requester("POST", "/db/guillotina/foo/foo", data=json.dumps({"@type": "Folder", "id": "foo"}))
+        resp, status = await requester(
+            "POST", "/db/guillotina/foo/foo", data=json.dumps({"@type": "Folder", "id": "foo"})
+        )
         assert status == 412
         assert resp["reason"] == "preconditionFailed"
         assert resp["type"] == "MaxDepthReached"


### PR DESCRIPTION
This PR does:

- Adds a configurable limit (`max_content_depth`) on height of the objects tree.

The motivation behind it is because there are some recursive functions in guillotina ( see [cached_principal_perimssion](https://github.com/plone/guillotina/blob/master/guillotina/security/policy.py#L140), for instance) where if we don't put a limit, we could run into python throwing `RecursionError`. We've found this at Onna.

I'll forward-port once we agree on the solution and it's merged.