### PR TITLE
improve memcached metrics probe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 5.3.67 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve memcached metrics probe [lferran]
 
 
 5.3.66 (2021-01-13)

--- a/guillotina/contrib/memcached/driver.py
+++ b/guillotina/contrib/memcached/driver.py
@@ -14,7 +14,6 @@ from typing import Optional
 
 import asyncio
 import backoff
-import copy
 import hashlib
 import logging
 
@@ -168,7 +167,7 @@ class MemcachedDriver:
                 except Exception:  # pragma: no cover
                     logger.error("Error initializing memcached driver", exc_info=True)
 
-                if _SEND_METRICS:
+                if _SEND_METRICS is True:
                     self._metrics_task = loop.create_task(metrics_probe(self.client))
 
     async def _create_client(self, settings: Dict[str, Any]) -> emcache.Client:
@@ -274,11 +273,11 @@ async def metrics_probe(client: emcache.Client, every: int = 30):
     """
     state: Optional[emcache.ConnectionPoolMetrics] = None
     while True:
-        state = await update_connection_pool_metrics(client, state)
+        state = update_connection_pool_metrics(client, state)
         await asyncio.sleep(every)
 
 
-async def update_connection_pool_metrics(
+def update_connection_pool_metrics(
     client: emcache.Client, last_state: Optional[emcache.ConnectionPoolMetrics] = None
 ) -> emcache.ConnectionPoolMetrics:
 
@@ -322,4 +321,4 @@ async def update_connection_pool_metrics(
             current_value = getattr(node_metrics, attr)
             counter.labels(node=node_label).inc(current_value - prev_value)
 
-    return copy.deepcopy(metrics)
+    return metrics

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -197,7 +197,9 @@ class TestUpdateConnectionPoolMetrics:
         metrics.create_connection_upper = 100.0
         return metrics
 
-    def test_updated_connection_pool_metrics_create_connection_latencies(self, avg, p50, p99, upper, metrics):
+    async def test_updated_connection_pool_metrics_create_connection_latencies(
+        self, avg, p50, p99, upper, metrics
+    ):
         node_metrics = {"node1": metrics}
         last_state = {"node1": metrics}
         client = mock.Mock()
@@ -210,7 +212,7 @@ class TestUpdateConnectionPoolMetrics:
         p99.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(99.0)])
         upper.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(100.0)])
 
-    def test_updated_connection_pool_metrics_create_connection_latencies_none(
+    async def test_updated_connection_pool_metrics_create_connection_latencies_none(
         self, avg, p50, p99, upper, metrics
     ):
         # Override default fixture values for simulating that latencies do not have

--- a/guillotina/tests/memcached/test_memcached_driver.py
+++ b/guillotina/tests/memcached/test_memcached_driver.py
@@ -18,6 +18,12 @@ MOCK_HOSTS = ["localhost:11211"]
 
 
 @pytest.fixture(scope="function")
+def dont_probe_metrics():
+    with mock.patch("guillotina.contrib.memcached.driver._SEND_METRICS", False):
+        yield
+
+
+@pytest.fixture(scope="function")
 def mocked_create_client(loop):
     with mock.patch("guillotina.contrib.memcached.driver.emcache.create_client") as create_client:
         f = asyncio.Future()
@@ -69,7 +75,7 @@ async def test_create_client_sets_configured_params(mocked_create_client, param,
 
 
 @pytest.mark.app_settings(MEMCACHED_SETTINGS)
-async def test_memcached_ops(memcached_container, guillotina_main, loop):
+async def test_memcached_ops(memcached_container, guillotina_main, loop, dont_probe_metrics):
     driver = await resolve_dotted_name("guillotina.contrib.memcached").get_driver()
     assert driver.initialized
     assert driver.client is not None
@@ -110,7 +116,9 @@ unsafe_keys = ["a" * 255, "foo bar", b"\x130".decode()]
 
 @pytest.mark.app_settings(MEMCACHED_SETTINGS)
 @pytest.mark.parametrize("unsafe_key", unsafe_keys)
-async def test_memcached_ops_are_safe_key(memcached_container, guillotina_main, loop, unsafe_key):
+async def test_memcached_ops_are_safe_key(
+    memcached_container, guillotina_main, unsafe_key, loop, dont_probe_metrics
+):
     driver = await resolve_dotted_name("guillotina.contrib.memcached").get_driver()
     await driver.get(unsafe_key)
     await driver.set(unsafe_key, b"foo")
@@ -173,7 +181,7 @@ class TestUpdateConnectionPoolMetrics:
             yield _upper
 
     @pytest.fixture
-    async def metrics(self):
+    def metrics(self):
         metrics = mock.Mock()
         metrics.cur_connections = 1
         metrics.connections_created = 1
@@ -189,22 +197,20 @@ class TestUpdateConnectionPoolMetrics:
         metrics.create_connection_upper = 100.0
         return metrics
 
-    async def test_updated_connection_pool_metrics_create_connection_latencies(
-        self, avg, p50, p99, upper, metrics
-    ):
+    def test_updated_connection_pool_metrics_create_connection_latencies(self, avg, p50, p99, upper, metrics):
         node_metrics = {"node1": metrics}
         last_state = {"node1": metrics}
         client = mock.Mock()
         client.cluster_managment.return_value.connection_pool_metrics.return_value = node_metrics
 
-        await update_connection_pool_metrics(client, last_state)
+        update_connection_pool_metrics(client, last_state)
 
         avg.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(10.0)])
         p50.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(50.0)])
         p99.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(99.0)])
         upper.assert_has_calls([mock.call.labels(node="node1"), mock.call.labels().set(100.0)])
 
-    async def test_updated_connection_pool_metrics_create_connection_latencies_none(
+    def test_updated_connection_pool_metrics_create_connection_latencies_none(
         self, avg, p50, p99, upper, metrics
     ):
         # Override default fixture values for simulating that latencies do not have
@@ -219,7 +225,7 @@ class TestUpdateConnectionPoolMetrics:
         client = mock.Mock()
         client.cluster_managment.return_value.connection_pool_metrics.return_value = node_metrics
 
-        await update_connection_pool_metrics(client, last_state)
+        update_connection_pool_metrics(client, last_state)
 
         avg.assert_not_called()
         p50.assert_not_called()


### PR DESCRIPTION
This PR improves in two ways:
- getting metrics no need to be async (as there is no IO ops)
- no need to deepcopy the metrics dict every time, as [emcache already returns a copy every time](https://github.com/pfreixes/emcache/blob/master/emcache/connection_pool.py#L348)


Will forward to master later, once merged