### PR TITLE
Fix memcached tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,6 +52,7 @@ jobs:
     env:
       DATABASE: ${{ matrix.database }}
       DB_SCHEMA: ${{ matrix.db_schema }}
+      MEMCACHED: "localhost:11211"
 
     steps:
       - name: Checkout the repository
@@ -69,6 +70,9 @@ jobs:
           pip install -r contrib-requirements.txt
           pip install -e .[test]
           pip install -e .[testdata]
+
+      - name: Start memcached image
+        uses: niden/actions-memcached@v7
 
       - name: Run tests
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 6.1.5 (unreleased)
 ------------------
 
+- Fix memcached tests not able to start docker image [lferran]
+
 - Fixing 6.1.4 release (anonymous users not working on search)
   [bloodbare]
 

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -638,9 +638,19 @@ def redis_container():
 
 @pytest.fixture(scope="session")
 def memcached_container():
-    host, port = os.environ["MEMCACHED"].split(":")
-    annotations["memcached"] = (host, port)
-    yield host, port  # provide the fixture value
+    if os.environ.get("MEMCACHED"):
+        host, port = os.environ["MEMCACHED"].split(":")
+        annotations["memcached"] = (host, port)
+        yield host, port
+
+    else:
+        import pytest_docker_fixtures
+
+        host, port = pytest_docker_fixtures.memcached_image.run()
+        annotations["memcached"] = (host, port)
+        yield host, port
+        pytest_docker_fixtures.memcached_image.stop()
+
     annotations["memcached"] = None
 
 

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -638,12 +638,9 @@ def redis_container():
 
 @pytest.fixture(scope="session")
 def memcached_container():
-    import pytest_docker_fixtures
-
-    host, port = pytest_docker_fixtures.memcached_image.run()
+    host, port = os.environ["MEMCACHED"].split(":")
     annotations["memcached"] = (host, port)
     yield host, port  # provide the fixture value
-    pytest_docker_fixtures.memcached_image.stop()
     annotations["memcached"] = None
 
 


### PR DESCRIPTION
For some reason `pytest-docker-fixtures` is not able to start the memcached image anymore when running the github actions job (locally it works though).


Adding server startup in a separate action step made the fix.