### PR TITLE
Cleaner memcached_container fixture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 6.1.5 (unreleased)
 ------------------
 
+- Cleaner memcached_container pytest fixture [lferran]
+
 - Fix memcached tests not able to start docker image [lferran]
 
 - Fixing 6.1.4 release (anonymous users not working on search)

--- a/guillotina/tests/conftest.py
+++ b/guillotina/tests/conftest.py
@@ -7,4 +7,4 @@ images.configure("cockroach", "cockroachdb/cockroach", "v2.1.6")
 images.configure("postgresql", version="10.9")
 
 
-pytest_plugins = ["guillotina.tests.fixtures"]
+pytest_plugins = ["guillotina.tests.fixtures", "pytest_docker_fixtures"]

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -637,20 +637,10 @@ def redis_container():
 
 
 @pytest.fixture(scope="session")
-def memcached_container():
-    if os.environ.get("MEMCACHED"):
-        host, port = os.environ["MEMCACHED"].split(":")
-        annotations["memcached"] = (host, port)
-        yield host, port
-
-    else:
-        import pytest_docker_fixtures
-
-        host, port = pytest_docker_fixtures.memcached_image.run()
-        annotations["memcached"] = (host, port)
-        yield host, port
-        pytest_docker_fixtures.memcached_image.stop()
-
+def memcached_container(memcached):
+    host, port = memcached
+    annotations["memcached"] = (host, port)
+    yield memcached
     annotations["memcached"] = None
 
 


### PR DESCRIPTION
now it doesn't duplicate the logic of `pytest-docker-fixtures` package