### PR TITLE
ISecurityInfo: field 'id' was missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.1.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ISecurityInfo: field 'id' was missing
+  [masipcat]
 
 
 6.1.6 (2021-02-25)

--- a/guillotina/catalog/catalog.py
+++ b/guillotina/catalog/catalog.py
@@ -118,6 +118,7 @@ class DefaultSecurityInfoAdapter(object):
     def __call__(self):
         """ access_users and access_roles """
         return {
+            "id": self.content.id,
             "path": get_content_path(self.content),
             "depth": get_content_depth(self.content),
             "parent_uuid": getattr(getattr(self.content, "__parent__", None), "uuid", None),

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -150,6 +150,7 @@ async def test_get_security_data(dummy_guillotina):
     ob = test_utils.create_content()
     adapter = get_adapter(ob, ISecurityInfo)
     data = adapter()
+    assert "id" in data
     assert "access_users" in data
     assert "access_roles" in data
 


### PR DESCRIPTION
This fixes the field `id` is not reindexed when an object is moved (renamed)