### PR TITLE
return 401 if NoPermissionToAdd is raised in defaultPOST

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@ CHANGELOG
 
 6.2.7 (unreleased)
 ------------------
-
-- Nothing changed yet.
+- Return 401 if NoPermissionToAdd is raised in defaultPOST
+  [nilbacardit26]
 
 
 6.2.6 (2021-04-12)

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -24,7 +24,6 @@ from guillotina.events import ObjectPermissionsViewEvent
 from guillotina.events import ObjectRemovedEvent
 from guillotina.events import ObjectVisitedEvent
 from guillotina.exceptions import ComponentLookupError
-from guillotina.exceptions import NoPermissionToAdd
 from guillotina.exceptions import PreconditionFailed
 from guillotina.i18n import default_message_factory as _
 from guillotina.interfaces import IAnnotations
@@ -207,8 +206,6 @@ class DefaultPOST(Service):
             obj = await create_content_in_container(
                 self.context, type_, new_id, check_constraints=True, **options
             )
-        except NoPermissionToAdd as e:
-            raise HTTPUnauthorized(content={"text": e.__repr__()})
         except ValueError as e:
             return ErrorResponse("CreatingObject", str(e), status=412)
 

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -24,6 +24,7 @@ from guillotina.events import ObjectPermissionsViewEvent
 from guillotina.events import ObjectRemovedEvent
 from guillotina.events import ObjectVisitedEvent
 from guillotina.exceptions import ComponentLookupError
+from guillotina.exceptions import NoPermissionToAdd
 from guillotina.exceptions import PreconditionFailed
 from guillotina.i18n import default_message_factory as _
 from guillotina.interfaces import IAnnotations
@@ -206,6 +207,8 @@ class DefaultPOST(Service):
             obj = await create_content_in_container(
                 self.context, type_, new_id, check_constraints=True, **options
             )
+        except NoPermissionToAdd as e:
+            raise HTTPUnauthorized(content={"text": e.__repr__()})
         except ValueError as e:
             return ErrorResponse("CreatingObject", str(e), status=412)
 

--- a/guillotina/exc_resp.py
+++ b/guillotina/exc_resp.py
@@ -3,6 +3,7 @@ from guillotina import error_reasons
 from guillotina.exceptions import ConflictIdOnContainer
 from guillotina.exceptions import DeserializationError
 from guillotina.exceptions import InvalidContentType
+from guillotina.exceptions import NoPermissionToAdd
 from guillotina.exceptions import NotAllowedContentType
 from guillotina.exceptions import PreconditionFailed
 from guillotina.exceptions import Unauthorized
@@ -82,6 +83,12 @@ register_handler_factory(
 
 register_handler_factory(
     Unauthorized,
+    exception_handler_factory(
+        error_reasons.UNAUTHORIZED, "Unauthorized", serialize_exc=True, klass=HTTPUnauthorized
+    ),
+)
+register_handler_factory(
+    NoPermissionToAdd,
     exception_handler_factory(
         error_reasons.UNAUTHORIZED, "Unauthorized", serialize_exc=True, klass=HTTPUnauthorized
     ),

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -104,6 +104,7 @@ def foobar_accessor(ob):
 
 
 configure.permission("example.MyPermission", "example permission")
+configure.permission("foo.Permission", "Foo permission")
 configure.permission("example.MyPermissionOwner", "example permission owner")
 configure.grant(role="guillotina.Owner", permission="example.MyPermissionOwner")
 
@@ -199,6 +200,28 @@ configure.register_configuration(
         schema=IExample,
         type_name="Example",
         behaviors=["guillotina.behaviors.dublincore.IDublinCore"],
+    ),
+    "contenttype",
+)
+
+
+class IExampleAddPermission(IResource):
+    pass
+
+
+@implementer(IExampleAddPermission)
+class ExampleAddPermission(Resource):  # type: ignore
+    pass
+
+
+configure.register_configuration(
+    ExampleAddPermission,
+    dict(
+        context=IContainer,
+        schema=IExampleAddPermission,
+        type_name="ExampleAddPermission",
+        behaviors=["guillotina.behaviors.dublincore.IDublinCore"],
+        add_permission="foo.Permission",
     ),
     "contenttype",
 )

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -1697,4 +1697,4 @@ async def test_default_post_without_add_permission(container_requester):
             "POST", "/db/guillotina/", data=json.dumps({"@type": "ExampleAddPermission"})
         )
         assert status == 401
-        assert "Not permission to add ExampleAddPermission on" in resp["text"]
+        assert "Not permission to add ExampleAddPermission on" in resp["message"]

--- a/guillotina/tests/test_api.py
+++ b/guillotina/tests/test_api.py
@@ -1689,3 +1689,12 @@ async def test_default_post_and_patch_handles_wrong_json_payload(container_reque
 
         _, status = await requester("PATCH", "/db/guillotina/", data=json.dumps("foobar"))
         assert status == 412
+
+
+async def test_default_post_without_add_permission(container_requester):
+    async with container_requester as requester:
+        resp, status = await requester(
+            "POST", "/db/guillotina/", data=json.dumps({"@type": "ExampleAddPermission"})
+        )
+        assert status == 401
+        assert "Not permission to add ExampleAddPermission on" in resp["text"]


### PR DESCRIPTION
Currently, I am getting 500 when NoPermissionToAdd is raised in the defaultPOST method when create_content_in_container is called. This happens when I am configuring a contentype with a custom add_permission. Raise HTTPUnauthorized instead