### PR TITLE
[5.x] No longer have dedicated read connection and do not use any prepared statements

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,9 +69,11 @@ jobs:
           pip install -r contrib-requirements.txt
           pip install -e .[test]
           pip install -e .[testdata]
+      
+      - name: memcache
+        uses: niden/actions-memcached@v7
 
       - name: Run tests
-        uses: niden/actions-memcached@v7
         env:
             MEMCACHED: "localhost:11211"
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,6 +71,9 @@ jobs:
           pip install -e .[testdata]
 
       - name: Run tests
+        uses: niden/actions-memcached@v7
+        env:
+            MEMCACHED: "localhost:11211"
         run: |
           pytest -rfE --reruns 2 --cov=guillotina -s --tb=native -v --cov-report xml --cov-append guillotina
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,10 +74,9 @@ jobs:
         uses: niden/actions-memcached@v7
 
       - name: Run tests
-        env:
-            MEMCACHED: "localhost:11211"
         run: |
-          pytest -rfE --reruns 2 --cov=guillotina -s --tb=native -v --cov-report xml --cov-append guillotina
+          MEMCACHED=localhost:11211 pytest -rfE --reruns 2 --cov=guillotina -s \
+          --tb=native -v --cov-report xml --cov-append guillotina
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 5.3.68 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- No longer have dedicated read connection and do not use any prepared statements
+  [vangheem]
 
 
 5.3.67 (2021-02-03)

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -995,13 +995,13 @@ WHERE tablename = '{}' AND indexname = '{}_parent_id_id_key';
     @restart_conn_on_exception
     async def get_next_tid(self, txn):
         with watch("next_tid"):
-            async with self.pool.acquire(timeout=self._manager._conn_acquire_timeout) as conn:
+            async with self.pool.acquire(timeout=self._conn_acquire_timeout) as conn:
                 return await conn.fetchval(self._next_tid_sql.format(schema=self._db_schema))
 
     @restart_conn_on_exception
     async def get_current_tid(self, txn):
         with watch("current_tid"):
-            async with self.pool.acquire(timeout=self._manager._conn_acquire_timeout) as conn:
+            async with self.pool.acquire(timeout=self._conn_acquire_timeout) as conn:
                 return await conn.fetchval(self._max_tid_sql.format(schema=self._db_schema))
 
     async def get_one_row(self, txn, sql, *args, prepare=False, metric="get_one_row"):

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -572,7 +572,7 @@ class PGConnectionManager:
             self._pool = await asyncpg.create_pool(
                 dsn=self._dsn,
                 max_size=self._pool_size,
-                min_size=2,
+                min_size=1,
                 connection_class=app_settings["pg_connection_class"],
                 loop=loop,
                 **kw,

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -734,7 +734,7 @@ class PostgresqlStorage(BaseStorage):
         else:
             await self._create(conn)
 
-    async def _create(self, conn: asyncpg):
+    async def _create(self, conn):
 
         # Check DB
         log.info("Creating initial database objects")

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -511,13 +511,19 @@ def redis_container():
 
 @pytest.fixture(scope="session")
 def memcached_container():
-    import pytest_docker_fixtures
+    if os.environ.get("MEMCACHED"):
+        host, port = os.environ["MEMCACHED"].split(":")
+        annotations["memcached"] = (host, port)
+        yield host, port
+        annotations["memcached"] = None
+    else:
+        import pytest_docker_fixtures
 
-    host, port = pytest_docker_fixtures.memcached_image.run()
-    annotations["memcached"] = (host, port)
-    yield host, port  # provide the fixture value
-    pytest_docker_fixtures.memcached_image.stop()
-    annotations["memcached"] = None
+        host, port = pytest_docker_fixtures.memcached_image.run()
+        annotations["memcached"] = (host, port)
+        yield host, port  # provide the fixture value
+        pytest_docker_fixtures.memcached_image.stop()
+        annotations["memcached"] = None
 
 
 class DBUsersRequester(ContainerRequesterAsyncContextManager):

--- a/guillotina/tests/fixtures.py
+++ b/guillotina/tests/fixtures.py
@@ -140,13 +140,14 @@ def get_db_settings(pytest_node=None):
         "user": "postgres",
         "host": annotations.get("pg_host", "localhost"),
         "port": annotations.get("pg_port", 5432),
-        "password": "",
+        "password": annotations.get("pg_password", ""),
     }
 
     options = dict(
         host=annotations.get("pg_host", "localhost"),
         port=annotations.get("pg_port", 5432),
         dbname=annotations.get("pg_db", "guillotina"),
+        password=annotations.get("pg_password", ""),
     )
 
     if annotations["testdatabase"] == "cockroachdb":
@@ -182,6 +183,7 @@ def db():
 
         annotations["pg_host"] = host
         annotations["pg_port"] = port
+        annotations["pg_password"] = os.environ.get("POSTGRES_PASSWORD", "")
 
         yield host, port  # provide the fixture value
 
@@ -477,7 +479,8 @@ def container_command(db):
     settings = get_db_settings()
     host = settings["databases"]["db"]["dsn"]["host"]
     port = settings["databases"]["db"]["dsn"]["port"]
-    conn = psycopg2.connect(f"dbname=guillotina user=postgres host={host} port={port}")
+    password = settings["databases"]["db"]["dsn"]["password"]
+    conn = psycopg2.connect(f"dbname=guillotina user=postgres host={host} port={port} password={password}")
     cur = conn.cursor()
     cur.execute(open(os.path.join(_dir, "data/tables.sql"), "r").read())
     cur.execute("COMMIT;")
@@ -485,7 +488,7 @@ def container_command(db):
     conn.close()
     yield {"settings": settings}
 
-    conn = psycopg2.connect(f"dbname=guillotina user=postgres host={host} port={port}")
+    conn = psycopg2.connect(f"dbname=guillotina user=postgres host={host} port={port} password={password}")
     cur = conn.cursor()
     cur.execute(
         """

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -238,30 +238,30 @@ async def test_query_stored_json(container_requester):
             "POST", "/db/guillotina/", data=json.dumps({"@type": "Item", "title": "Item2", "id": "item2"})
         )
 
-        conn = requester.db.storage.read_conn
-        result = await conn.fetch(
-            """
-select json from {0}
-where json->>'type_name' = 'Item' AND json->>'container_id' = 'guillotina'
-order by json->>'id'
-""".format(
-                requester.db.storage._objects_table_name
+        async with requester.db.storage.pool.acquire() as conn:
+            result = await conn.fetch(
+                """
+    select json from {0}
+    where json->>'type_name' = 'Item' AND json->>'container_id' = 'guillotina'
+    order by json->>'id'
+    """.format(
+                    requester.db.storage._objects_table_name
+                )
             )
-        )
-        print(f"{result}")
-        assert len(result) == 2
-        assert json.loads(result[0]["json"])["id"] == "item1"
-        assert json.loads(result[1]["json"])["id"] == "item2"
+            print(f"{result}")
+            assert len(result) == 2
+            assert json.loads(result[0]["json"])["id"] == "item1"
+            assert json.loads(result[1]["json"])["id"] == "item2"
 
-        result = await conn.fetch(
-            """
-select json from {0}
-where json->>'id' = 'item1' AND json->>'container_id' = 'guillotina'
-""".format(
-                requester.db.storage._objects_table_name
+            result = await conn.fetch(
+                """
+    select json from {0}
+    where json->>'id' = 'item1' AND json->>'container_id' = 'guillotina'
+    """.format(
+                    requester.db.storage._objects_table_name
+                )
             )
-        )
-        assert len(result) == 1
+            assert len(result) == 1
 
 
 @pytest.mark.app_settings(PG_CATALOG_SETTINGS)

--- a/guillotina/tests/utils.py
+++ b/guillotina/tests/utils.py
@@ -113,8 +113,8 @@ class ContainerRequesterAsyncContextManager:
         return self.requester
 
     async def __aexit__(self, exc_type, exc, tb):
-        _, status = await self.requester("DELETE", "/db/guillotina")
-        assert status in (200, 404)
+        resp, status = await self.requester("DELETE", "/db/guillotina")
+        assert status in (200, 404), f"{status}: {resp}"
 
 
 class wrap_request:


### PR DESCRIPTION
The purpose of this PR is to get rid of our dedicated read connection and use of prepared statements:

- use of dedicated read conn for subset of queries can in some cases cause some lock contention between transactions
- use of prepared statements prevents people from using pgbouncer in `transaction` mode. asyncpg already automatically creates prepared statements for all sql. By removing the use of prepared statements, you can now set the statement cache size to 0 for asyncpg and have guillotina work with pgbouncer.

I also fixed memcache test issues.