### PR TITLE
[master] No longer have dedicated read connection and do not use any prepared statements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer have dedicated read connection and do not use any prepared statements
+  [vangheem]
 
 
 6.2.6 (2021-04-12)

--- a/guillotina/commands/__init__.py
+++ b/guillotina/commands/__init__.py
@@ -217,7 +217,7 @@ class Command(object):
                 logger.info(f"Waiting for {task._coro.__qualname__} to finish")
                 try:
                     await asyncio.wait_for(asyncio.shield(task), 1)
-                except asyncio.TimeoutError:
+                except (asyncio.TimeoutError, asyncio.CancelledError):
                     logger.warning(f"Timeout for {task._coro.__qualname__}")
             except (AttributeError, KeyError):
                 pass

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -477,7 +477,6 @@ class PGConnectionManager:
         self._dsn = dsn
         self._pool_size = pool_size
         self._pool = None
-        self._read_conn = None
         self._connection_options = connection_options or {}
         self._conn_acquire_timeout = conn_acquire_timeout
         self._lock = asyncio.Lock()
@@ -709,8 +708,6 @@ class PostgresqlStorage(BaseStorage):
             await self._create(conn)
 
     async def _create(self, conn):
-        if conn is None:
-            conn = self.read_conn
         # Check DB
         log.info("Creating initial database objects")
 

--- a/guillotina/db/storages/pg.py
+++ b/guillotina/db/storages/pg.py
@@ -464,9 +464,6 @@ class PGConnectionManager:
     class to manage pool of connections
     """
 
-    _next_tid_sql = "SELECT nextval('{schema}.tid_sequence');"
-    _max_tid_sql = "SELECT last_value FROM {schema}.tid_sequence;"
-
     def __init__(
         self,
         dsn=None,
@@ -593,6 +590,9 @@ class PostgresqlStorage(BaseStorage):
     _connection_manager_class = PGConnectionManager
     _objects_table_name = "objects"
     _blobs_table_name = "blobs"
+
+    _next_tid_sql = "SELECT nextval('{schema}.tid_sequence');"
+    _max_tid_sql = "SELECT last_value FROM {schema}.tid_sequence;"
 
     _object_schema = {
         "zoid": f"VARCHAR({MAX_UID_LENGTH}) NOT NULL PRIMARY KEY",

--- a/guillotina/tests/test_catalog.py
+++ b/guillotina/tests/test_catalog.py
@@ -240,30 +240,30 @@ async def test_query_stored_json(container_requester):
             "POST", "/db/guillotina/", data=json.dumps({"@type": "Item", "title": "Item2", "id": "item2"})
         )
 
-        conn = requester.db.storage.read_conn
-        result = await conn.fetch(
-            """
-select json from {0}
-where json->>'type_name' = 'Item' AND json->>'container_id' = 'guillotina'
-order by json->>'id'
-""".format(
-                requester.db.storage._objects_table_name
+        async with requester.db.storage.pool.acquire() as conn:
+            result = await conn.fetch(
+                """
+    select json from {0}
+    where json->>'type_name' = 'Item' AND json->>'container_id' = 'guillotina'
+    order by json->>'id'
+    """.format(
+                    requester.db.storage._objects_table_name
+                )
             )
-        )
-        print(f"{result}")
-        assert len(result) == 2
-        assert json.loads(result[0]["json"])["id"] == "item1"
-        assert json.loads(result[1]["json"])["id"] == "item2"
+            print(f"{result}")
+            assert len(result) == 2
+            assert json.loads(result[0]["json"])["id"] == "item1"
+            assert json.loads(result[1]["json"])["id"] == "item2"
 
-        result = await conn.fetch(
-            """
-select json from {0}
-where json->>'id' = 'item1' AND json->>'container_id' = 'guillotina'
-""".format(
-                requester.db.storage._objects_table_name
+            result = await conn.fetch(
+                """
+    select json from {0}
+    where json->>'id' = 'item1' AND json->>'container_id' = 'guillotina'
+    """.format(
+                    requester.db.storage._objects_table_name
+                )
             )
-        )
-        assert len(result) == 1
+            assert len(result) == 1
 
 
 @pytest.mark.app_settings(PG_CATALOG_SETTINGS)


### PR DESCRIPTION
The purpose of this PR is to get rid of our dedicated read connection and use of prepared statements:

- use of dedicated read conn for subset of queries can in some cases cause some lock contention between transactions
- use of prepared statements prevents people from using pgbouncer in `transaction` mode. asyncpg already automatically creates prepared statements for all sql. By removing the use of prepared statements, you can now set the statement cache size to 0 for asyncpg and have guillotina work with pgbouncer.
