### PR TITLE
PG catalog unrestriced search and parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 6.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- PG Catalog unrestricted search build count query
+- PG Catalog __or, __and operators
+  [rboixaderg]
 
 
 6.3.6 (2021-05-10)

--- a/guillotina/contrib/catalog/pg/parser.py
+++ b/guillotina/contrib/catalog/pg/parser.py
@@ -34,7 +34,7 @@ class Parser(BaseParser):
         wheres = []
         arguments = []
         selects = []
-        for _, (sfield, svalue) in enumerate(parsed_value):
+        for sfield, svalue in parsed_value:
             result = self.process_queried_field(sfield, svalue)
             if result is not None:
                 wheres.append(result[0])

--- a/guillotina/contrib/catalog/pg/parser.py
+++ b/guillotina/contrib/catalog/pg/parser.py
@@ -11,6 +11,7 @@ from guillotina.interfaces import ISearchParser
 from guillotina.interfaces.catalog import ICatalogUtility
 
 import typing
+import urllib
 
 
 _type_mapping = {"int": int, "float": float}
@@ -27,19 +28,20 @@ class ParsedQueryInfo(BasicParsedQueryInfo):
 @configure.adapter(for_=(ICatalogUtility, IResource), provides=ISearchParser, name="default")
 class Parser(BaseParser):
     def process_compound_field(self, field, value, operator):
-        if not isinstance(value, dict):
+        parsed_value = urllib.parse.parse_qsl(urllib.parse.unquote(value))
+        if not isinstance(parsed_value, list):
             return None
         wheres = []
         arguments = []
         selects = []
-        for sfield, svalue in value.items():
+        for _, (sfield, svalue) in enumerate(parsed_value):
             result = self.process_queried_field(sfield, svalue)
             if result is not None:
                 wheres.append(result[0])
                 arguments.extend(result[1])
                 selects.extend(result[2])
         if len(wheres) > 0:
-            return (operator, wheres), arguments, selects
+            return (operator, wheres), arguments, selects, field
 
     def process_queried_field(
         self, field: str, value

--- a/guillotina/contrib/catalog/pg/utility.py
+++ b/guillotina/contrib/catalog/pg/utility.py
@@ -207,7 +207,10 @@ class PGSearchUtility(DefaultSearchUtility):
         return sql, sql_arguments
 
     def build_count_query(
-        self, context, query: ParsedQueryInfo
+        self,
+        context,
+        query: ParsedQueryInfo,
+        unrestricted: bool = False,
     ) -> typing.Tuple[str, typing.List[typing.Any]]:
         sql_arguments = []
         sql_wheres = []
@@ -218,7 +221,7 @@ class PGSearchUtility(DefaultSearchUtility):
             sql_arguments.append(query["wheres_arguments"][idx])
             arg_index += 1
 
-        sql_wheres.extend(self.get_default_where_clauses(context))
+        sql_wheres.extend(self.get_default_where_clauses(context, unrestricted=unrestricted))
 
         txn = get_transaction()
         if txn is None:
@@ -330,7 +333,7 @@ class PGSearchUtility(DefaultSearchUtility):
         # also do count...
         total = len(results)
         if total >= query["size"] or query["_from"] != 0:
-            sql, arguments = self.build_count_query(context, query)
+            sql, arguments = self.build_count_query(context, query, unrestricted=unrestricted)
             logger.debug(f"Running search:\n{sql}\n{arguments}")
             async with txn.lock:
                 records = await conn.fetch(sql, *arguments)


### PR DESCRIPTION
Added unrestriced in build_count_query function

Modify pg catalog parser to use __or operator. 

I don't see any place that explain how we can use __or operator, then I modify it to allow recieve an encoded query

