### PR TITLE
Set id/name of group to ease the access later via id/name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ CHANGELOG
   using app_settings["ttl_email_validation"] in the utility of the
   email_validation. By default is 3660s.
   [nilbacardit26]
+- Fix docs: Create group with id/name
+  [ksuess]
 
 - doc: installation: fix duplicated line and link to contrib/dbusers
   [jotare]

--- a/docs/changelogs/6.x.rst
+++ b/docs/changelogs/6.x.rst
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+6.4.0 (2021-11.06)
+-------------------
+
+- Fix docs: Create group with id/name
+  [ksuess]

--- a/docs/source/developer/security.md
+++ b/docs/source/developer/security.md
@@ -217,7 +217,8 @@ Let's add a group named `todo_viewer`:
 
     {
         "@type": "Group",
-        "name": "todo_viewer"
+        "id": "todo_viewer",
+        "title": "TODO Viewer"
     }
 
 

--- a/docs/source/developer/security.md
+++ b/docs/source/developer/security.md
@@ -224,14 +224,21 @@ Let's add a group named `todo_viewer`:
 
     HTTP/1.1 201 Created
     Content-Type: application/json
-    Location: http://localhost:8080/db/todo/groups/14f624ef23094362961df0e083cd77e4
+    Location: http://localhost:8071/db/todo/groups/todo_viewer
 
     {
-        "@id": "http://localhost:8080/db/todo/groups/14f624ef23094362961df0e083cd77e4",
-        "@name": "14f624ef23094362961df0e083cd77e4",
+        "@id": "http://localhost:8080/db/todo/groups/todo_viewer",
+        "@name": "todo_viewer",
         "@type": "Group",
         "@uid": "6e6|ff3|14f624ef23094362961df0e083cd77e4",
-        "UID": "6e6|ff3|14f624ef23094362961df0e083cd77e4"
+        "groupname": null,
+        "id": "todo_viewer",
+        "title": null,
+        "roles": [],
+        "users": {
+            "items": [],
+            "items_total": 0
+        }
     }
 ```
 

--- a/docs/source/developer/security.md
+++ b/docs/source/developer/security.md
@@ -224,7 +224,7 @@ Let's add a group named `todo_viewer`:
 
     HTTP/1.1 201 Created
     Content-Type: application/json
-    Location: http://localhost:8071/db/todo/groups/todo_viewer
+    Location: http://localhost:8080/db/todo/groups/todo_viewer
 
     {
         "@id": "http://localhost:8080/db/todo/groups/todo_viewer",


### PR DESCRIPTION
POST /db/todo/groups HTTP/1.1
Accept: application/json
Authorization: Basic cm9vdDpyb290
Content-Type: application/json
Host: localhost:8080

{
    "@type": "Group",
    "name": "todo_viewer"
}

leads to a generated id/name

Set also title