### PR TITLE
Add render_options to email validation utility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ CHANGELOG
 - Documentation: Add info about catalog_max_results
   [ksuess]
 
+- Add a dict parameter `render_options` to pass custom values to
+  rendered template in EmailValidationUtility
+  [jotare]
 
 6.4.0rc2 (2021-11-22)
 ---------------------

--- a/guillotina/contrib/email_validation/utility.py
+++ b/guillotina/contrib/email_validation/utility.py
@@ -43,6 +43,7 @@ class EmailValidationUtility:
         context_description=None,
         ttl=3660,
         data=None,
+        render_options={},
     ):
         # from_user will be mostly anonymous
         registry = await get_registry()
@@ -99,6 +100,7 @@ class EmailValidationUtility:
             link=link,
             last_date=last_date,
             task=task_description,
+            **render_options,
         )
         await util.send(recipient=email, sender=from_email, subject=task_description, html=template)
 


### PR DESCRIPTION
Hi!
Working with the email validation utility I miss some functionality to pass custom options (context) to Jinja while rendering the validation template. If that makes sense, I've added a dict parameter to pass this custom context to the template