### PR TITLE
Fix @pytest.mark.app_settings modified original settings dictionary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ CHANGELOG
 6.4.0rc3 (unreleased)
 ---------------------
 
+- Fix @pytest.mark.app_settings modified original settings dictionary
+  [masipcat]
+
 - Fix previous change in mailer utility
   [masipcat]
 

--- a/guillotina/factory/app.py
+++ b/guillotina/factory/app.py
@@ -40,7 +40,7 @@ logger = glogging.getLogger("guillotina")
 
 
 def update_app_settings(settings):
-    for key, value in settings.items():
+    for key, value in deepcopy(settings).items():
         if isinstance(app_settings.get(key), dict) and isinstance(value, dict):
             app_settings[key].update(value)
         else:

--- a/guillotina/tests/test_configure.py
+++ b/guillotina/tests/test_configure.py
@@ -251,6 +251,26 @@ async def test_app_settings_are_overwritten_by_pytest_marks(container_requester)
     assert "storage" in app_settings["databases"]["db"]
 
 
+@pytest.mark.app_settings(
+    {
+        "applications": ["guillotina.contrib.dbusers"],
+        "auth_validation_tasks": {"custom_value": {}},
+    }
+)
+async def test_app_settings_mark_can_modify_another_package(dummy_guillotina):
+    from guillotina import app_settings
+
+    assert "custom_value" in app_settings["auth_validation_tasks"], app_settings["auth_validation_tasks"]
+
+
+@pytest.mark.app_settings({"applications": ["guillotina.contrib.dbusers"]})
+async def test_app_settings_mark_doesnt_affected_other_tests(dummy_guillotina):
+    from guillotina import app_settings
+
+    # This ensures the previous test did not mutate the app settings
+    assert "custom_value" not in app_settings["auth_validation_tasks"], app_settings["auth_validation_tasks"]
+
+
 async def test_register_service_with_path(container_requester):
     cur_count = len(configure.get_configurations("guillotina.tests", "service"))
 


### PR DESCRIPTION
The bug can be reproduced with `pytest guillotina/tests -k test_app_settings_mark -vvv` (and undoing the fix)