### PR TITLE
being able to call do_action with super powers using the utility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ CHANGELOG
 6.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Being able to call do_action with super powers in the Workflow
+  utility
+  [nilbacardit26]
 
 
 6.4.1 (2022-07-27)

--- a/guillotina/contrib/workflows/utility.py
+++ b/guillotina/contrib/workflows/utility.py
@@ -60,17 +60,18 @@ def create_workflow_factory(proto_name, proto_definition):
         def initial_state(self):
             return self._initial_state
 
-        async def do_action(self, action, comments):
+        async def do_action(self, action, comments, bypass_permission_check=False):
             available_actions = self.actions
             if action not in available_actions:
                 raise HTTPPreconditionFailed(content={"reason": "Unavailable action"})
 
             action_def = available_actions[action]
-            policy = get_security_policy()
-            if "check_permission" in action_def and not policy.check_permission(
-                action_def["check_permission"], self.context
-            ):
-                raise HTTPUnauthorized()
+            if bypass_permission_check is False:
+                policy = get_security_policy()
+                if "check_permission" in action_def and not policy.check_permission(
+                    action_def["check_permission"], self.context
+                ):
+                    raise HTTPUnauthorized()
 
             # Change permission
             new_state = action_def["to"]

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     extras_require={
         "test": [
             "pytest>=3.8.0,<6.3.0",
-            "docker",
+            "docker>=5.0.0,<6.0.0",
             "backoff",
             "psycopg2-binary",
             "pytest-asyncio<=0.13.0",


### PR DESCRIPTION
In some situations in my internal code, I want to be able to switch the state of the workflow on behalf of other users without checking any security policies.