### PR TITLE
adding slash in path__starts queries when context is not the container

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ CHANGELOG
 - Deps: replace aioredis with redis-py
 - Deps: updated flake8 so it won't depend on 'importlib-metadata<5'
   [masipcat]
+- Fix path__starts. Add a slash when parsing the path of the query if
+  the context of the search is not the container, to avoid getting the
+  results of contexts that starts with the same path.
+  [nbacardit26]
 
 
 6.4.2 (2022-08-25)

--- a/guillotina/catalog/parser.py
+++ b/guillotina/catalog/parser.py
@@ -83,9 +83,11 @@ class BaseParser:
         # Path specific use case
         if "path__starts" in params:
             path = params.pop("path__starts")
-            path = "/" + path.strip("/")
+            path = "/" + path.lstrip("/")
         else:
             path = get_content_path(self.context)
+            if path.endswith("/") is False and path != "/":
+                path = path + "/"
         params["path__starts"] = path
 
         if "_size" in params:


### PR DESCRIPTION
I found bug when searching with pg catalog on contexts that starts with the same path than others:
```
/db/container/foo_folder/Item1
/db/container/foo_folder2/Item2

/db/container/foo_folder/@search
```
it returned Item1 and Item2