### PR TITLE
Adding render_options when registering a user using @users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ CHANGELOG
   the context of the search is not the container, to avoid getting the
   results of contexts that starts with the same path.
   [nbacardit26]
+- Adding render_options when registering a user.
 
 
 6.4.2 (2022-08-25)

--- a/guillotina/api/login.py
+++ b/guillotina/api/login.py
@@ -365,6 +365,7 @@ class RegisterUsers(Service):
                 context_description=self.context.title,
                 redirect_url=redirect_url,
                 data=payload,
+                render_options=payload.get("render_options", {}),
             )
         else:
             raise HTTPNotAcceptable()


### PR DESCRIPTION
Sometimes when registering a user we want to pass some render arguments to render custom email templates