### PR TITLE
Deleting import zope.interface implements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removing implements import in components/interfaces.py
+  [nilbacardit26]
 
 
 6.4.3 (2023-10-11)

--- a/guillotina/component/interfaces.py
+++ b/guillotina/component/interfaces.py
@@ -16,7 +16,6 @@
 # fmt: off
 from guillotina.component._compat import _BLANK
 from zope.interface import Attribute
-from zope.interface import implements
 from zope.interface import Interface
 # BBB 2011-09-09, import interfaces from zope.interface
 from zope.interface.interfaces import _IBaseAdapterRegistration


### PR DESCRIPTION
Every time I install guillotina as a dependency I encounter this error:
Error importing plugin "guillotina.tests.fixtures": cannot import name 'implements' from 'zope.interface. implements is not there anymore in version 6.1 'zope.interface

I do not know what this line does, implements is not used anywhere. I passed all the test without this line. Some of you know why is it there?
https://github.com/plone/guillotina/blob/master/guillotina/component/interfaces.py#L19



 