### PR TITLE
feat: Add development server command

### DIFF
--- a/guillotina/_settings.py
+++ b/guillotina/_settings.py
@@ -69,6 +69,7 @@ app_settings: Dict[str, Any] = {
         "dbvacuum": "guillotina.commands.vacuum.VacuumCommand",
         "migrate": "guillotina.commands.migrate.MigrateCommand",
         "gen-key": "guillotina.commands.crypto.CryptoCommand",
+        "serve-dev": "guillotina.commands.server_dev.ServerDevCommand",
     },
     "json_schema_definitions": {},  # json schemas available to reference in docs
     "default_layer": interfaces.IDefaultLayer,

--- a/guillotina/commands/server.py
+++ b/guillotina/commands/server.py
@@ -7,14 +7,6 @@ class ServerCommand(Command):
 
     def get_parser(self):
         parser = super(ServerCommand, self).get_parser()
-        parser.add_argument(
-            "-r",
-            "--reload",
-            action="store_true",
-            dest="reload",
-            help="Auto reload on code changes",
-            default=False,
-        )
         parser.add_argument("--port", help="Override port to run this server on", default=None, type=int)
         parser.add_argument("--host", help="Override host to run this server on", default=None)
 
@@ -35,12 +27,12 @@ class ServerCommand(Command):
                 app,
                 host=host,
                 port=port,
-                reload=arguments.reload,
                 log_config=loggers or LOGGING_CONFIG,
                 **app.server_settings.get("uvicorn", {}),
             )
             server = Server(config)
             await server.serve()
+
         elif arguments.asgi_server == "hypercorn":
             from hypercorn.asyncio import serve  # type: ignore
             from hypercorn.config import Config  # type: ignore

--- a/guillotina/commands/server_dev.py
+++ b/guillotina/commands/server_dev.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+import sys
+from guillotina.commands import Command
+from guillotina.asgi import AsgiApp
+from guillotina.traversal import TraversalRouter
+
+
+def create_dev_app():
+    """
+    Create the ASGI application for development with the config file from environment.
+    """
+    config_file = os.getenv("GUILLOTINA_CONFIG_FILE", "config.yaml")
+    router = TraversalRouter()
+    return AsgiApp(config_file=config_file, settings={}, loop=None, router=router)
+
+
+# Create app instance at module level for uvicorn to find
+app = create_dev_app()
+
+
+class ServerDevCommand(Command):
+    """
+    Command to run the server in development mode with auto-reload.
+    Uses subprocess to ensure clean reloads.
+    """
+
+    description = "Serve Guillotina in development mode with auto-reload"
+
+    def get_parser(self):
+        """
+        Parses command-line arguments for the serve-dev command.
+        """
+        parser = super().get_parser()
+        parser.add_argument("--watch", help="Directory to watch for changes", default=".")
+        parser.add_argument("--host", help="Host to bind the server to", default="127.0.0.1")
+        parser.add_argument("--port", help="Port to bind the server to", type=int, default=8080)
+        return parser
+
+    def run(self, arguments, settings, app):
+        """
+        Run the development server using uvicorn as subprocess for reliable reload.
+        """
+        config_file = arguments.configuration
+        if not os.path.exists(config_file):
+            print(f"Error: Configuration file not found at '{config_file}'")
+            sys.exit(1)
+
+        print(f"Using configuration file: {config_file}")
+        print(f"Watching directory: {arguments.watch}")
+        print(f"Server will be available at: http://{arguments.host}:{arguments.port}")
+
+        # Pass the config file path via environment variable
+        env = os.environ.copy()
+        env["GUILLOTINA_CONFIG_FILE"] = config_file
+
+        # Use the current module as the app entry point
+        module_path = f"{self.__module__}:app"
+
+        command = [
+            "uvicorn",
+            module_path,
+            "--reload",
+            f"--reload-dir={arguments.watch}",
+            f"--host={arguments.host}",
+            f"--port={arguments.port}",
+        ]
+
+        print(f"Starting development server with command: {' '.join(command)}")
+
+        try:
+            subprocess.run(command, env=env, check=True)
+        except FileNotFoundError:
+            print("Error: 'uvicorn' command not found.")
+            print("Please ensure uvicorn is installed in your environment.")
+            sys.exit(1)
+        except subprocess.CalledProcessError:
+            print("Development server exited with an error.")
+        except KeyboardInterrupt:
+            print("\nDevelopment server stopped.")

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "backoff",
         "multidict",
         "typing_extensions",
+        "watchfiles>=0.16.1",
     ],
     extras_require={
         "test": [
@@ -105,7 +106,7 @@ setup(
             'aiohttp>=3.0.0,<3.6.0;python_version<"3.8"',
             'aiohttp>=3.6.0,<4.0.0;python_version>="3.8"',
         ],
-        "redis": ['redis>=4.3.0'],
+        "redis": ["redis>=4.3.0"],
         "mailer": ["html2text>=2018.1.9", "aiosmtplib>=1.0.6"],
         "memcached": ["emcache"],
         "validation": ["pytz==2020.1"],


### PR DESCRIPTION
- Introduced a new command `serve-dev` for running the server in development mode with auto-reload functionality.
- Updated `setup.py` to include `watchfiles>=0.16.1` as a dependency.
- Modified `_settings.py` to register the new `serve-dev` command.
- Removed the reload option from the existing server command to streamline functionality.