### PR TITLE
Read the docs: Fixing Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     python: "3.10"
 
 sphinx:
-  configuration: docs/source/conf.py   # adjust if your conf.py lives elsewhere
+  configuration: docs/source/conf.py
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/source/conf.py   # adjust if your conf.py lives elsewhere
 
 python:
-  version: 3.9
   install:
-    - method: setuptools
+    - requirements: docs-requirements.txt
+    - method: pip
       path: .
-  requirements_file: docs-requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
+version: 2
+
 build:
-    image: latest
+  image: latest
 
 python:
-    version: 3.7
-    setup_py_install: true
-    requirements_file: docs-requirements.txt
+  version: 3.9
+  install:
+    - method: setuptools
+      path: .
+  requirements_file: docs-requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ CHANGELOG
 
 - Adding POST @groups endpoint in dbusers
 - Upgrading postgres version when running test in conftest
-- Updating .readthedocs.yml to version 2
+- Updating .readthedocs.yml to version 2. Updating docs dependencies,
+  upgrading sphinx to version 8
   [nilbacardit26]
 
 7.0.5 (2025-04-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ CHANGELOG
   installed, which is controlled by a try excep clause.
   Passing labels instead works always when watch is imported
   from metrics.watch
-- Updating .readthedocs.yml
+- Updating .readthedocs.yml.
   [nilbacardit26]
 
 7.0.5 (2025-04-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ CHANGELOG
 
 - Adding POST @groups endpoint in dbusers
 - Upgrading postgres version when running test in conftest
+- Instancing watch in driver redis failed if prometheus_client is not
+  installed, which is controlled by a try excep clause.
+  Passing labels instead works always when watch is imported
+  from metrics.watch
   [nilbacardit26]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,8 @@ CHANGELOG
   installed, which is controlled by a try excep clause.
   Passing labels instead works always when watch is imported
   from metrics.watch
+- Updating .readthedocs.yml
   [nilbacardit26]
-
 
 7.0.5 (2025-04-03)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ CHANGELOG
   installed, which is controlled by a try excep clause.
   Passing labels instead works always when watch is imported
   from metrics.watch
-- Updating .readthedocs.yml.
+- Updating .readthedocs.yml to version 2
   [nilbacardit26]
 
 7.0.5 (2025-04-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,6 @@ CHANGELOG
 
 - Adding POST @groups endpoint in dbusers
 - Upgrading postgres version when running test in conftest
-- Instancing watch in driver redis failed if prometheus_client is not
-  installed, which is controlled by a try excep clause.
-  Passing labels instead works always when watch is imported
-  from metrics.watch
 - Updating .readthedocs.yml to version 2
   [nilbacardit26]
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,9 +1,9 @@
-recommonmark
-sphinx==1.8.2
-sphinx-guillotina-theme==1.0.7
-sphinxcontrib.httpdomain==1.7.0
-sphinxcontrib-httpexample==0.9.0
-sphinx-autodoc-typehints==1.5.2
-docutils==0.13.1
-readme-renderer==22.0
+myst-parser==4.0.1
+sphinx==8.1.3
+sphinx-guillotina-theme==1.0.8  # TODO release Version 1.0.8 once the PR is merged https://github.com/guillotinaweb/sphinx-guillotina-theme/pull/3
+sphinxcontrib.httpdomain==1.8.1
+sphinxcontrib-httpexample==1.3
+sphinx-autodoc-typehints==3.0.1
+docutils==0.21
+readme-renderer==43.0
 async-asgi-testclient<2.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,8 +31,6 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 import pkg_resources
-from recommonmark.parser import CommonMarkParser
-from recommonmark.transform import AutoStructify
 
 extensions = [
     "sphinx.ext.coverage",
@@ -42,6 +40,7 @@ extensions = [
     "sphinxcontrib.httpexample",
     "guillotina.documentation.sphinx",
     "sphinx_guillotina_theme",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -50,7 +49,10 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 # The encoding of source files.
 #
@@ -61,7 +63,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Guillotina"
-copyright = "2020, Ramon Navarro Bosch & Nathan Van Gheem"
+copyright = "2025, Ramon Navarro Bosch & Nathan Van Gheem"
 author = "Ramon Navarro Bosch & Nathan Van Gheem"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -132,7 +134,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = "guillotina"
-html_use_smartypants = False
+smartquotes = False
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -339,10 +341,6 @@ texinfo_documents = [
     )
 ]
 
-source_parsers = {".md": CommonMarkParser}
-
-source_suffix = [".rst", ".md"]
-
 # Documents to append as an appendix to all manuals.
 #
 # texinfo_appendices = []
@@ -358,8 +356,3 @@ source_suffix = [".rst", ".md"]
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-
-# At the bottom of conf.py
-def setup(app):
-    app.add_config_value("recommonmark_config", {"auto_toc_tree_section": "Contents"}, True)
-    app.add_transform(AutoStructify)


### PR DESCRIPTION
Fixing the read the docs. Working locally:

<img width="1900" height="833" alt="image" src="https://github.com/user-attachments/assets/8edd410c-789c-4c0c-b48b-109fd8527946" />

This PR needs this to be released:
https://github.com/guillotinaweb/sphinx-guillotina-theme/pull/3
As the upgrade to sphinx 8 requires a little change in the the sphinx-guillotina-theme

Then adapt the release version sphinx-guillotina-theme in the docs-requirements.txt 

sphinx-guillotina-theme==1.0.8

