### PR TITLE
Fix mailer list address headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 7.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix list-valued mailer recipient headers for ``To`` and ``Cc``.
+  [nilbacardit26]
 
 
 7.1.0 (2026-05-07)

--- a/guillotina/contrib/mailer/utility.py
+++ b/guillotina/contrib/mailer/utility.py
@@ -33,6 +33,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def format_address_header(value):
+    if isinstance(value, (list, tuple)):
+        return ", ".join(item for item in value if item)
+    return value
+
+
 @configure.utility(provides=IMailEndpoint, name="smtp")
 class SMTPMailEndpoint(object):
     def __init__(self):
@@ -178,9 +184,10 @@ class MailerUtility:
 
         message["Subject"] = subject
         message["From"] = sender
-        message["To"] = recipient
-        if cc is not None:
-            message["Cc"] = cc
+        message["To"] = format_address_header(recipient)
+        cc_header = format_address_header(cc)
+        if cc_header:
+            message["Cc"] = cc_header
         if message_id is not None:
             message["Message-Id"] = message_id
         else:

--- a/guillotina/tests/mailer/test_mailer.py
+++ b/guillotina/tests/mailer/test_mailer.py
@@ -1,10 +1,43 @@
 import pytest
 
 from guillotina.component import get_utility
+from guillotina.contrib.mailer.utility import MailerUtility
 from guillotina.interfaces import IMailer
 
 
 pytestmark = pytest.mark.asyncio
+
+
+class CapturingMailerUtility(MailerUtility):
+    async def _send(self, sender, recipients, message, endpoint_name="default"):
+        self.sender = sender
+        self.recipients = recipients
+        self.message = message
+        self.endpoint_name = endpoint_name
+
+
+async def test_send_mail_formats_list_address_headers():
+    mailer = CapturingMailerUtility(
+        {"mailer": {"default_sender": "sender@example.com", "domain": "example.com"}}
+    )
+
+    await mailer.send(
+        recipient=["primary@example.com", "other@example.com"],
+        subject="Test Mail",
+        text="Good mail",
+        cc=["cc@example.com", "second-cc@example.com"],
+    )
+
+    assert mailer.recipients == [
+        "primary@example.com",
+        "other@example.com",
+        "cc@example.com",
+        "second-cc@example.com",
+    ]
+    assert mailer.message["To"] == "primary@example.com, other@example.com"
+    assert mailer.message["Cc"] == "cc@example.com, second-cc@example.com"
+    assert "To: primary@example.com, other@example.com" in mailer.message.as_string()
+    assert "Cc: cc@example.com, second-cc@example.com" in mailer.message.as_string()
 
 
 @pytest.mark.app_settings(


### PR DESCRIPTION
I found a regression when using python 3.12 regarding the cc on the mailers