### PR TITLE
Copy cloud file storage when duplicating content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ CHANGELOG
   including dict-valued multi-file fields, so duplicated content does not share
   mutable file blobs with the source object.
   [nilbacardit26]
+- Replace the docs build usage of deprecated ``pkg_resources`` with
+  ``importlib.metadata`` and update ``sphinxcontrib-httpexample`` for
+  compatibility with current setuptools.
+  [nilbacardit26]
 
 
 7.1.1 (2026-05-15)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ CHANGELOG
 7.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Copy backing file storage when duplicating content with cloud file fields,
+  including dict-valued multi-file fields, so duplicated content does not share
+  mutable file blobs with the source object.
+  [nilbacardit26]
 
 
 7.1.1 (2026-05-15)

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@ myst-parser==4.0.1
 sphinx==8.1.3
 sphinx-guillotina-theme==1.0.9
 sphinxcontrib.httpdomain==1.8.1
-sphinxcontrib-httpexample==1.3
+sphinxcontrib-httpexample==2.0
 sphinx-autodoc-typehints==3.0.1
 docutils==0.21
 readme-renderer==43.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-import pkg_resources
+from importlib.metadata import version as package_version
 
 extensions = [
     "sphinx.ext.coverage",
@@ -71,7 +71,7 @@ author = "Ramon Navarro Bosch & Nathan Van Gheem"
 # built documents.
 #
 # The short X.Y version.
-version = pkg_resources.get_distribution("guillotina").version.split(".dev")[0]
+version = package_version("guillotina").split(".dev")[0]
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -13,7 +13,6 @@ from guillotina import configure, task_vars
 from guillotina._cache import BEHAVIOR_CACHE, FACTORY_CACHE, PERMISSIONS_CACHE, SCHEMA_CACHE
 from guillotina._settings import app_settings
 from guillotina.annotations import AnnotationData
-from guillotina.api.service import DictFieldProxy
 from guillotina.auth.users import ANONYMOUS_USER_ID, ROOT_USER_ID
 from guillotina.behaviors import apply_markers
 from guillotina.browser import get_physical_path
@@ -691,6 +690,8 @@ async def _copy_duplicated_cloud_files(source, destination, request) -> None:
                     request,
                 )
             elif IDict.providedBy(field) and ICloudFileField.providedBy(field.value_type):
+                from guillotina.api.service import DictFieldProxy
+
                 values = getattr(source_field_context, name, None) or {}
                 if getattr(destination_field_context, name, None) is values:
                     setattr(destination_field_context, name, copy.copy(values))

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import pathlib
 from datetime import datetime
@@ -12,10 +13,11 @@ from guillotina import configure, task_vars
 from guillotina._cache import BEHAVIOR_CACHE, FACTORY_CACHE, PERMISSIONS_CACHE, SCHEMA_CACHE
 from guillotina._settings import app_settings
 from guillotina.annotations import AnnotationData
+from guillotina.api.service import DictFieldProxy
 from guillotina.auth.users import ANONYMOUS_USER_ID, ROOT_USER_ID
 from guillotina.behaviors import apply_markers
 from guillotina.browser import get_physical_path
-from guillotina.component import get_adapter, get_utilities_for, get_utility, query_utility
+from guillotina.component import get_adapter, get_multi_adapter, get_utilities_for, get_utility, query_utility
 from guillotina.component.factory import Factory
 from guillotina.db import uid
 from guillotina.db.interfaces import ITransaction
@@ -36,14 +38,17 @@ from guillotina.exceptions import (
     PreconditionFailed,
     TransactionNotFound,
 )
+from guillotina.fields import CloudFileField
 from guillotina.interfaces import (
     DEFAULT_ADD_PERMISSION,
     IAddons,
     IAnnotations,
     IAsyncBehavior,
     IBehavior,
+    ICloudFileField,
     IConstrainTypes,
     IContainer,
+    IFileManager,
     IFolder,
     IGetOwner,
     IIDChecker,
@@ -62,10 +67,17 @@ from guillotina.interfaces import (
 from guillotina.profile import profilable
 from guillotina.registry import REGISTRY_DATA_KEY
 from guillotina.response import HTTPConflict
+from guillotina.schema.interfaces import IDict
 from guillotina.schema.utils import get_default_from_schema
 from guillotina.security.security_code import PrincipalPermissionManager
 from guillotina.transactions import get_transaction
-from guillotina.utils import get_object_by_uid, get_security_policy, navigate_to, valid_id
+from guillotina.utils import (
+    get_current_request,
+    get_object_by_uid,
+    get_security_policy,
+    navigate_to,
+    valid_id,
+)
 from guillotina.utils.auth import get_authenticated_user_id
 
 
@@ -647,6 +659,55 @@ async def get_all_behaviors(content, create=False, load=True) -> list:
     return behaviors
 
 
+async def _copy_cloud_file_field(
+    source_context, source_field, destination_context, destination_field, request
+) -> None:
+    file = source_field.get(source_field.context or source_context)
+    if file is None:
+        return
+
+    destination_field.set(destination_field.context or destination_context, None)
+    source_manager = get_multi_adapter((source_context, request, source_field), IFileManager)
+    destination_manager = get_multi_adapter((destination_context, request, destination_field), IFileManager)
+    await source_manager.copy(destination_manager)
+
+
+async def _copy_duplicated_cloud_files(source, destination, request) -> None:
+    factory = get_cached_factory(source.type_name)
+    contexts = [(factory.schema, source, destination)]
+    destination_behaviors = dict(await get_all_behaviors(destination, load=True))
+    for behavior_schema, source_behavior in await get_all_behaviors(source, load=True):
+        contexts.append((behavior_schema, source_behavior, destination_behaviors[behavior_schema]))
+
+    for schema, source_field_context, destination_field_context in contexts:
+        for name in schema.names(all=True):
+            field = schema[name]
+            if ICloudFileField.providedBy(field):
+                await _copy_cloud_file_field(
+                    source,
+                    field.bind(source_field_context),
+                    destination,
+                    field.bind(destination_field_context),
+                    request,
+                )
+            elif IDict.providedBy(field) and ICloudFileField.providedBy(field.value_type):
+                values = getattr(source_field_context, name, None) or {}
+                if getattr(destination_field_context, name, None) is values:
+                    setattr(destination_field_context, name, copy.copy(values))
+                for key, file in list(values.items()):
+                    if file is None:
+                        continue
+                    source_proxy = DictFieldProxy(key, source_field_context, name)
+                    destination_proxy = DictFieldProxy(key, destination_field_context, name)
+                    await _copy_cloud_file_field(
+                        source,
+                        CloudFileField(__name__=name).bind(source_proxy),
+                        destination,
+                        CloudFileField(__name__=name).bind(destination_proxy),
+                        request,
+                    )
+
+
 async def duplicate(
     context: IResource,
     destination: Optional[Union[IResource, str]] = None,
@@ -744,6 +805,8 @@ async def duplicate(
         for key, value in anno_data.items():
             new_anno_data[key] = value
         await annotations_container.async_set(anno_id, new_anno_data)
+
+    await _copy_duplicated_cloud_files(context, new_obj, get_current_request())
 
     await notify(
         ObjectDuplicatedEvent(

--- a/guillotina/files/adapter.py
+++ b/guillotina/files/adapter.py
@@ -251,7 +251,7 @@ class DBFileStorageManagerAdapter:
         # too much storage manager logic here? only way to give file manager
         # more control for plugins
         await to_storage_manager.start(dm)
-        await to_storage_manager.append(dm, to_storage_manager.iter_data(), 0)
+        await to_storage_manager.append(dm, self.iter_data(), 0)
         await to_storage_manager.finish(dm)
         await dm.finish()
 

--- a/guillotina/test_package.py
+++ b/guillotina/test_package.py
@@ -497,7 +497,9 @@ class InMemoryFileManager:
 
     async def copy(self, to_storage_manager, to_dm):
         file = self.field.get(self.field.context or self.context)
-        generator = get_multi_adapter((self.context, self.field), IFileNameGenerator)
+        generator = get_multi_adapter(
+            (to_storage_manager.context, to_storage_manager.field), IFileNameGenerator
+        )
         new_uri = await apply_coroutine(generator)
         _tmp_files[new_uri] = _tmp_files[file.uri]
         _tmp_files[new_uri] = tempfile.mkstemp()[1]

--- a/guillotina/tests/test_attachment.py
+++ b/guillotina/tests/test_attachment.py
@@ -387,6 +387,83 @@ async def test_copy_file_ob(manager_type, redis_container, container_requester):
 
 
 @pytest.mark.parametrize("manager_type", _pytest_params)
+async def test_duplicate_copies_file_storage(manager_type, redis_container, container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/",
+            data=json.dumps(
+                {
+                    "@type": "Item",
+                    "@behaviors": [IAttachment.__identifier__, IMultiAttachment.__identifier__],
+                    "id": "source",
+                }
+            ),
+        )
+        assert status == 201
+
+        response, status = await requester(
+            "PATCH",
+            "/db/guillotina/source/@upload/file",
+            data=b"single-file",
+            headers={"x-upload-size": str(len(b"single-file"))},
+        )
+        assert status == 200
+
+        response, status = await requester(
+            "PATCH",
+            "/db/guillotina/source/@upload/files/key1",
+            data=b"multi-file",
+            headers={"x-upload-size": str(len(b"multi-file"))},
+        )
+        assert status == 200
+
+        response, status = await requester(
+            "POST", "/db/guillotina/source/@duplicate", data=json.dumps({"new_id": "copy"})
+        )
+        assert status == 200
+
+        async with transaction(db=requester.db, abort_when_done=True) as txn:
+            root = await txn.manager.get_root(txn)
+            container = await root.async_get("guillotina")
+            source = await container.async_get("source")
+            duplicate = await container.async_get("copy")
+            source_attachment = IAttachment(source)
+            duplicate_attachment = IAttachment(duplicate)
+            source_multi = IMultiAttachment(source)
+            duplicate_multi = IMultiAttachment(duplicate)
+            await source_attachment.load()
+            await duplicate_attachment.load()
+            await source_multi.load()
+            await duplicate_multi.load()
+            if manager_type == "db":
+                assert source_attachment.file._blob.bid != duplicate_attachment.file._blob.bid
+                assert source_multi.files["key1"]._blob.bid != duplicate_multi.files["key1"]._blob.bid
+            else:
+                assert source_attachment.file.uri != duplicate_attachment.file.uri
+                assert source_multi.files["key1"].uri != duplicate_multi.files["key1"].uri
+
+        response, status = await requester("GET", "/db/guillotina/copy/@download/file")
+        assert status == 200
+        assert response == b"single-file"
+        response, status = await requester("GET", "/db/guillotina/copy/@download/files/key1")
+        assert status == 200
+        assert response == b"multi-file"
+
+        response, status = await requester("DELETE", "/db/guillotina/copy/@delete/file")
+        assert status == 200
+        response, status = await requester("DELETE", "/db/guillotina/copy/@delete/files/key1")
+        assert status == 200
+
+        response, status = await requester("GET", "/db/guillotina/source/@download/file")
+        assert status == 200
+        assert response == b"single-file"
+        response, status = await requester("GET", "/db/guillotina/source/@download/files/key1")
+        assert status == 200
+        assert response == b"multi-file"
+
+
+@pytest.mark.parametrize("manager_type", _pytest_params)
 async def test_tus_unfinished_error(manager_type, redis_container, container_requester):
     async with container_requester as requester:
         _, status = await requester(


### PR DESCRIPTION
We have a bug when duplicating content that has CloudFileField fields, we are copying the same metadata references to the destination object, leading to problems later when uploading images, for instance, to the destination object in the same key reference of the dict inside of the CloudFileField, having incongruent 404 references to the blob due to the replacement/deletion

With this we are making a copy of the blob in the destination.

PR related: https://github.com/plone/guillotina_gcloudstorage/pull/35

