### PR TITLE
Refactor MCP tools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ CHANGELOG
 7.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- MCP: remove redundant ``serialize_resource`` and confusing
+  ``notify_modified`` built-in tools. Use ``resolve_path`` with
+  ``include_serialized=true`` for full resource JSON.
+  [rboixaderg]
 
 
 7.1.1 (2026-05-15)

--- a/docs/source/contrib/mcp.md
+++ b/docs/source/contrib/mcp.md
@@ -1,44 +1,305 @@
-# MCP
+# Guillotina MCP
 
-`guillotina.contrib.mcp` provides a low-level MCP integration layer built on
-the official `mcp.server.lowlevel` primitives (no FastMCP wrapper).
+`guillotina.contrib.mcp` exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Guillotina. LLM clients (Cursor, VS Code, etc.) connect over **Streamable HTTP** and use JSON-RPC 2.0 to list and call tools, and to read resources.
+
+The integration uses the official `mcp.server.lowlevel` primitives (no FastMCP wrapper). Tools run **in-process** with the same request context, transaction, and security as a normal Guillotina API call.
+
+## Requirements
+
+- **Python 3.10+** (the `mcp` package does not support older versions).
+- Install the optional extra: `pip install "guillotina[mcp]"`.
 
 ## Installation
 
-```bash
-pip install "guillotina[mcp]"
-```
+1. Install the MCP extra:
+
+   ```bash
+   pip install "guillotina[mcp]"
+   ```
+
+2. Add the contrib to your application:
+
+   ```yaml
+   applications:
+     - guillotina
+     - guillotina.contrib.mcp
+   ```
+
+3. (Optional) Install the `mcp` addon on a container if you use container-level addon registration.
 
 ## Configuration
 
-```yaml
-applications:
-  - guillotina
-  - guillotina.contrib.mcp
+Default settings are provided by the contrib; override them in your app config:
 
+```yaml
 mcp:
   enabled: true
   server_name: guillotina-mcp
   default_child_limit: 50
 ```
 
-## Runtime endpoints
+| Setting | Description |
+|--------|-------------|
+| `mcp.enabled` | When `false`, the registry reports disabled metadata. Default: `true`. |
+| `mcp.server_name` | Name sent in MCP `initialize` (`serverInfo.name`). Default: `guillotina-mcp`. |
+| `mcp.default_child_limit` | Default `limit` for `list_children` when not specified. Default: `50`. |
 
-- `GET /@mcp`: registry metadata and registered tools.
-- `GET /@mcp/tools`: tool list and schemas.
-- `POST /@mcp/tools/invoke`: executes one tool with payload
-  `{ "tool": "<name>", "arguments": { ... } }`.
-- `GET /@mcp/server/status`: validates low-level SDK availability.
+The tool registry is loaded as utility `mcp_tool_registry` (`IMCPToolRegistry`).
+
+## Endpoint and authentication
+
+The MCP protocol is exposed on the **container** (or any resource) that acts as context for tool execution:
+
+- **URL**: `POST /{db}/{container_path}/@mcp/protocol`
+- **Example**: `POST http://localhost:8080/db/guillotina/@mcp/protocol`
+- **Permission**: `guillotina.MCPExecute` (granted to `guillotina.Manager` by default).
+- **Authentication**: Same as the rest of Guillotina (Basic auth or Bearer JWT from `@login`). The authenticated user’s permissions apply to every tool call.
+
+Clients must send:
+
+```http
+Content-Type: application/json
+Accept: application/json, text/event-stream
+```
+
+Without the `Accept` header, the transport may respond with **406 Not Acceptable**.
+
+Example: list tools via JSON-RPC:
+
+```bash
+curl -X POST -u root:root \
+  "http://localhost:8080/db/guillotina/@mcp/protocol" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+The service delegates to the MCP Streamable HTTP transport, which writes the response directly to the ASGI channel. Guillotina returns a dummy response marked as already sent so no duplicate body is written.
+
+### Cursor / VS Code
+
+Point the MCP client at the protocol URL and pass auth headers, for example in `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "guillotina": {
+      "url": "http://localhost:8080/db/guillotina/@mcp/protocol",
+      "headers": {
+        "Authorization": "Basic cm9vdDpyb290"
+      }
+    }
+  }
+}
+```
+
+On connect, the client calls `tools/list` and `resources/list` to discover capabilities.
 
 ## Built-in tools
 
-- `resolve_path`: resolve a path and return basic metadata.
-- `list_children`: list child resources from a folder-like resource.
-- `serialize_resource`: execute Guillotina serialization adapters.
-- `notify_modified`: emit an `ObjectModifiedEvent`.
+All default tools are **read-only**. They do not create, update, or delete content.
 
-The tool registry is implemented as a Guillotina utility and cache invalidation
-is handled by subscribers on object add/modify/remove events.
+Paths are resolved relative to the **MCP service context** (usually the container) unless they start with `/`, in which case they are resolved from the container root.
 
-`list_children` prefers catalog-backed lookup when a catalog utility is
-available and falls back to `async_items()` iteration when it is not.
+| Tool | Cacheable | Description |
+|------|-----------|-------------|
+| `resolve_path` | yes | Resolve a path. Default: minimal metadata (`id`, `@type`, `title`, `path`). Use `include_serialized=true` for full JSON (like `GET`). |
+| `list_children` | yes | List direct children of a folder-like resource. Catalog when available, else `async_items()`. Paginate with `page` and `limit` (max 200). |
+| `search` | yes | Catalog search. Requires a real catalog utility (not the default in-memory one). |
+
+### Tool parameters (summary)
+
+**`resolve_path`**
+
+- `path` (string, default `"/"`): absolute (`/foo`) or relative (`foo`) path.
+- `include_serialized` (boolean, default `false`): when `true`, adds a `serialized` key with full Guillotina JSON (fields, behaviors, etc., per registered serializers).
+
+**`list_children`**
+
+- `path` (string, default `"/"`).
+- `limit` (integer, 1–200, default from `mcp.default_child_limit`).
+- `page` (integer, default `1`): used when falling back to `async_items()`.
+- `include_serialized` (boolean, default `false`): full JSON per child in each item.
+
+**`search`**
+
+- `query` (object, **required**): Guillotina catalog query. Supports `type_name`, `path__starts`, `creators`, date filters, etc. Pagination: `b_start`, `b_size` (max 1000). Limit fields: `_metadata` (e.g. `"id,type_name,title,path"`).
+
+Example `tools/call` (minimal metadata):
+
+```bash
+curl -X POST -u root:root \
+  "http://localhost:8080/db/guillotina/@mcp/protocol" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 2,
+    "params": {
+      "name": "resolve_path",
+      "arguments": {"path": "/"}
+    }
+  }'
+```
+
+Example with full resource JSON:
+
+```json
+{
+  "name": "resolve_path",
+  "arguments": {"path": "/my-item", "include_serialized": true}
+}
+```
+
+There is **no** built-in tool to create or modify content. Register custom tools (see below) or use the REST API (`POST` / `PATCH`).
+
+## Built-in MCP resources
+
+Resources are read-only JSON documents exposed via `resources/list` and `resources/read`:
+
+| Name | URI | Description |
+|------|-----|-------------|
+| `info` | `guillotina://resources/info` | Guillotina version, container id/path, enabled addons. |
+| `health` | `guillotina://resources/health` | Database connectivity status. |
+| `config` | `guillotina://resources/config` | MCP settings and loaded applications. |
+| `users` | `guillotina://resources/users` | List users when `guillotina.contrib.dbusers` is enabled. |
+| `catalog` | `guillotina://resources/catalog` | Whether a catalog utility is configured. |
+| `summary` | `guillotina://resources/summary` | Summary of a resource; optional query `?path=/some/id` on the URI. |
+
+Example:
+
+```bash
+curl -X POST -u root:root \
+  "http://localhost:8080/db/guillotina/@mcp/protocol" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "resources/read",
+    "id": 3,
+    "params": {"uri": "guillotina://resources/summary?path=/"}
+  }'
+```
+
+## Caching (optional — Redis not required)
+
+**Redis is not required to use MCP.** The protocol endpoint and all built-in tools work without `guillotina.contrib.redis`. If Redis is unavailable, the registry disables tool caching and every call runs directly against the database or catalog.
+
+When `guillotina.contrib.redis` is enabled, cacheable tools (`resolve_path`, `list_children`, `search`) store results in Redis for one hour (including responses with `include_serialized=true`; cache keys differ per argument set).
+
+Subscribers invalidate the cache on `IObjectAddedEvent`, `IObjectModifiedEvent`, and `IBeforeObjectRemovedEvent` so listings and search results stay consistent after content changes.
+
+## Permissions
+
+| Permission | Purpose |
+|------------|---------|
+| `guillotina.MCPExecute` | Call `@mcp/protocol` and execute tools. |
+| `guillotina.MCPView` | Reserved for view-level MCP services (granted to Manager/Owner). |
+
+Adjust role grants in your application if non-managers should use MCP.
+
+## Adding tools for your project
+
+Register tools on the shared `IMCPToolRegistry` utility. The usual pattern is a subscriber on application startup:
+
+```python
+# myapp/mcp_tools.py
+from typing import Any, Dict
+
+from guillotina import configure
+from guillotina.component import query_utility
+from guillotina.contrib.mcp.interfaces import IMCPToolRegistry
+from guillotina.interfaces import IApplicationInitializedEvent
+from guillotina.utils import navigate_to
+
+
+async def count_items_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    path = arguments.get("path", "/")
+    target = await navigate_to(context, path)
+    total = await target.async_len() if hasattr(target, "async_len") else 0
+    return {"path": path, "count": total}
+
+
+@configure.subscriber(for_=IApplicationInitializedEvent)
+async def register_project_mcp_tools(event):
+    registry = query_utility(IMCPToolRegistry)
+    if registry is None:
+        return
+    registry.register_tool(
+        name="count_items",
+        description="Count direct children of a folder-like resource at path.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative Guillotina path",
+                    "default": "/",
+                }
+            },
+        },
+        handler=count_items_tool,
+        cacheable=True,
+    )
+```
+
+Ensure `configure.scan("myapp.mcp_tools")` runs (or the module is imported from your package `includeme`).
+
+### Tool handler contract
+
+Each handler is an async callable:
+
+```python
+async def handler(context, request, arguments: dict) -> dict:
+    ...
+```
+
+- `context`: the resource the `@mcp` service was invoked on (typically the container).
+- `request`: the active Guillotina request (auth, serializers, etc.).
+- `arguments`: JSON object from the MCP client (`tools/call` params).
+- **Return value**: JSON-serializable `dict` (encoded as text content in the protocol response).
+
+Use `registry.register_tool(...)` with a unique `name`. Avoid clashing with built-in names: `resolve_path`, `list_children`, `search`.
+
+Set `cacheable=True` only if the result is safe to cache and your tool does not perform writes. Use an argument name other than `include_serialized` for heavy optional payloads, or set `cacheable=False`.
+
+### Adding MCP resources
+
+```python
+registry.register_resource(
+    name="project_info",
+    uri="guillotina://resources/project_info",
+    description="Project-specific metadata for the LLM.",
+    endpoint="@mcp/resources/project_info",
+    handler=my_async_handler,  # async def handler(request) -> dict
+)
+```
+
+Resource handlers receive the HTTP `request` (with URI query params merged into `request.query` when using `?path=` on the URI).
+
+### Alternative: custom registry factory
+
+For many tools, subclass `MCPToolRegistry` and register your factory in `load_utilities`:
+
+```yaml
+load_utilities:
+  mcp_tool_registry:
+    provides: guillotina.contrib.mcp.interfaces.IMCPToolRegistry
+    factory: myapp.mcp.MyMCPToolRegistry
+    settings: {}
+```
+
+Call `register_tool` from your subclass `__init__` after `super().__init__()`.
+
+## How clients discover parameters
+
+MCP clients do not hardcode tool parameters. On connect they call `tools/list` and receive each tool’s `name`, `description`, and `inputSchema` (JSON Schema). The LLM uses that schema when calling `tools/call`.
+
+For `search`, the `query` object is a free-form catalog query; document supported keys in your tool `description` or in project-specific docs so the model uses the right filters (`type_name`, `path__startswith`, `_metadata`, etc.).
+
+## Limitations
+
+- **No content creation or updates** in the default tool set. Use custom tools or the REST API (`POST` / `PATCH`).
+- **`search`** and catalog-backed **`list_children`** need a configured catalog utility (e.g. `guillotina.contrib.catalog.pg`).
+- MCP runs in the **same process** as Guillotina; heavy tool logic affects request workers.

--- a/guillotina/contrib/mcp/tools.py
+++ b/guillotina/contrib/mcp/tools.py
@@ -3,8 +3,6 @@ from typing import Any, Awaitable, Callable, Dict, List, Tuple
 
 from guillotina.catalog.catalog import DefaultSearchUtility
 from guillotina.component import query_multi_adapter, query_utility
-from guillotina.event import notify
-from guillotina.events import ObjectModifiedEvent
 from guillotina.interfaces import IResourceSerializeToJson, IResourceSerializeToJsonSummary
 from guillotina.interfaces.catalog import ICatalogUtility
 from guillotina.utils import get_content_path, get_current_container, navigate_to
@@ -16,7 +14,14 @@ RESOLVE_PATH_SCHEMA = {
     "type": "object",
     "properties": {
         "path": {"type": "string", "description": "Absolute or relative Guillotina path", "default": "/"},
-        "include_serialized": {"type": "boolean", "default": False},
+        "include_serialized": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, include full JSON from Guillotina serializers "
+                "(same as GET on the resource). Default response is minimal: id, @type, title, path."
+            ),
+        },
     },
 }
 
@@ -37,24 +42,12 @@ LIST_CHILDREN_SCHEMA = {
             "default": 1,
             "description": "Page number (1-based). Use with limit to paginate.",
         },
-        "include_serialized": {"type": "boolean", "default": False},
+        "include_serialized": {
+            "type": "boolean",
+            "default": False,
+            "description": "When true, include full serialized JSON per child (heavier response).",
+        },
     },
-}
-
-SERIALIZE_RESOURCE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "path": {"type": "string", "description": "Absolute or relative Guillotina path", "default": "/"}
-    },
-}
-
-NOTIFY_MODIFIED_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "path": {"type": "string", "description": "Absolute or relative Guillotina path"},
-        "payload": {"type": "object", "description": "Payload sent to ObjectModifiedEvent", "default": {}},
-    },
-    "required": ["path"],
 }
 
 SEARCH_SCHEMA = {
@@ -265,20 +258,6 @@ async def _list_children_from_async_items(
     }
 
 
-async def serialize_resource_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
-    target, resolved_path = await _resolve_target(context, arguments.get("path", "/"))
-    return {"path": resolved_path, "serialized": await _serialize_resource(target, request)}
-
-
-async def notify_modified_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
-    target, resolved_path = await _resolve_target(context, arguments.get("path"))
-    payload = arguments.get("payload", {})
-    if not isinstance(payload, dict):
-        raise ValueError("Tool argument 'payload' must be an object")
-    await notify(ObjectModifiedEvent(target, payload=payload))
-    return {"path": resolved_path, "notified": True, "payload_keys": sorted(payload.keys())}
-
-
 async def search_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
     catalog = _get_catalog_utility()
     if catalog is None:
@@ -292,31 +271,24 @@ def default_tools(default_child_limit: int = 50) -> List[Tuple[str, str, Dict[st
     return [
         (
             "resolve_path",
-            "Resolve a Guillotina path and return basic resource metadata.",
+            (
+                "Resolve a Guillotina path. By default returns minimal metadata "
+                "(id, @type, title, path). Set include_serialized=true for full JSON (like GET)."
+            ),
             RESOLVE_PATH_SCHEMA,
             resolve_path_tool,
             True,
         ),
         (
             "list_children",
-            "List child resources from a folder-like Guillotina resource. Max 200 per page; use 'page' to paginate.",
+            (
+                "List child resources from a folder-like Guillotina resource. "
+                "Max 200 per page; use 'page' to paginate. "
+                "Set include_serialized=true for full JSON per child."
+            ),
             LIST_CHILDREN_SCHEMA,
             functools.partial(list_children_tool, default_limit=default_child_limit),
             True,
-        ),
-        (
-            "serialize_resource",
-            "Serialize a Guillotina resource using the registered serializers.",
-            SERIALIZE_RESOURCE_SCHEMA,
-            serialize_resource_tool,
-            False,
-        ),
-        (
-            "notify_modified",
-            "Emit an ObjectModifiedEvent for a resource path, triggering subscribers.",
-            NOTIFY_MODIFIED_SCHEMA,
-            notify_modified_tool,
-            False,
         ),
         (
             "search",

--- a/guillotina/tests/mcp/test_mcp.py
+++ b/guillotina/tests/mcp/test_mcp.py
@@ -81,11 +81,7 @@ async def test_protocol_tools_list(container_requester):
         response, status = await _protocol(requester, "tools/list")
         assert status == 200
         names = {t["name"] for t in response["result"]["tools"]}
-        assert "search" in names
-        assert "list_children" in names
-        assert "resolve_path" in names
-        assert "serialize_resource" in names
-        assert "notify_modified" in names
+        assert names == {"list_children", "resolve_path", "search"}
 
 
 @pytest.mark.app_settings(MCP_SETTINGS)


### PR DESCRIPTION
## Summary

This PR simplifies the built-in MCP toolset and expands the MCP contrib documentation.

### Tool changes

- **Removed `serialize_resource`** — redundant with `resolve_path` when `include_serialized=true` (same Guillotina serializers as a `GET` on the resource).
- **Removed `notify_modified`** — emitting `ObjectModifiedEvent` from an MCP tool was confusing and could trigger subscribers unexpectedly without a real content change.
- **Clarified `resolve_path` and `list_children`** — improved tool descriptions and JSON Schema `description` fields for `include_serialized`, so LLM clients discover the minimal vs full JSON behavior via `tools/list`.

The default built-in toolset is now read-only: `resolve_path`, `list_children`, and `search`.

### Documentation

Rewrote and expanded `docs/source/contrib/mcp.md` to cover:

- Installation, configuration, and requirements (Python 3.10+, `guillotina[mcp]`)
- Streamable HTTP endpoint (`POST /@mcp/protocol`), authentication, and client setup (curl, Cursor/VS Code)
- Built-in tools, parameters, and examples (`tools/call`)
- Built-in MCP resources (`info`, `health`, `config`, `users`, `catalog`, `summary`)
- Optional Redis caching and cache invalidation
- Permissions (`guillotina.MCPExecute`, `guillotina.MCPView`)
- How to register custom tools and resources
- Limitations (no default write tools, catalog requirements for `search`)

## Motivation

- Reduce overlap between tools so agents use a single, predictable path for resource JSON.
- Avoid a built-in tool that fires modification events without an actual edit.
- Give integrators and LLM clients enough documentation to connect and use MCP without reading the source.

## Files changed

| File | Change |
|------|--------|
| `guillotina/contrib/mcp/tools.py` | Remove 2 tools; clarify schemas and descriptions |
| `docs/source/contrib/mcp.md` | Full MCP integration guide |
| `guillotina/tests/mcp/test_mcp.py` | Assert exact built-in tool set |
| `CHANGELOG.rst` | Document breaking tool removal |
