### PR TITLE
Secure MCP content access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,11 @@ CHANGELOG
 7.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- MCP: enforce Guillotina content permissions for tools and resources,
+  require ``ViewContent`` for full serialized JSON, isolate cached tool
+  responses by principal/container/context, and invalidate MCP cache on
+  permission changes.
+  [rboixaderg]
 
 
 7.1.2 (2026-05-22)

--- a/docs/source/contrib/mcp.md
+++ b/docs/source/contrib/mcp.md
@@ -40,7 +40,7 @@ mcp:
 
 | Setting | Description |
 |--------|-------------|
-| `mcp.enabled` | When `false`, the registry reports disabled metadata. Default: `true`. |
+| `mcp.enabled` | When `false`, the protocol endpoint is unavailable. Default: `true`. |
 | `mcp.server_name` | Name sent in MCP `initialize` (`serverInfo.name`). Default: `guillotina-mcp`. |
 | `mcp.default_child_limit` | Default `limit` for `list_children` when not specified. Default: `50`. |
 
@@ -53,7 +53,7 @@ The MCP protocol is exposed on the **container** (or any resource) that acts as 
 - **URL**: `POST /{db}/{container_path}/@mcp/protocol`
 - **Example**: `POST http://localhost:8080/db/guillotina/@mcp/protocol`
 - **Permission**: `guillotina.MCPExecute` (granted to `guillotina.Manager` by default).
-- **Authentication**: Same as the rest of Guillotina (Basic auth or Bearer JWT from `@login`). The authenticated user’s permissions apply to every tool call.
+- **Authentication**: Same as the rest of Guillotina (Basic auth or Bearer JWT from `@login`). The authenticated user’s permissions apply to every tool and resource call.
 
 Clients must send:
 
@@ -112,14 +112,14 @@ Paths are resolved relative to the **MCP service context** (usually the containe
 **`resolve_path`**
 
 - `path` (string, default `"/"`): absolute (`/foo`) or relative (`foo`) path.
-- `include_serialized` (boolean, default `false`): when `true`, adds a `serialized` key with full Guillotina JSON (fields, behaviors, etc., per registered serializers).
+- `include_serialized` (boolean, default `false`): when `true`, adds a `serialized` key with full Guillotina JSON (fields, behaviors, etc., per registered serializers). Requires `guillotina.ViewContent` on the resolved resource, like a normal `GET`.
 
 **`list_children`**
 
 - `path` (string, default `"/"`).
 - `limit` (integer, 1–200, default from `mcp.default_child_limit`).
 - `page` (integer, default `1`): used when falling back to `async_items()`.
-- `include_serialized` (boolean, default `false`): full JSON per child in each item.
+- `include_serialized` (boolean, default `false`): full JSON per child in each item. Requires `guillotina.ViewContent` on each serialized child, like a normal `GET`.
 
 **`search`**
 
@@ -186,7 +186,7 @@ curl -X POST -u root:root \
 
 **Redis is not required to use MCP.** The protocol endpoint and all built-in tools work without `guillotina.contrib.redis`. If Redis is unavailable, the registry disables tool caching and every call runs directly against the database or catalog.
 
-When `guillotina.contrib.redis` is enabled, cacheable tools (`resolve_path`, `list_children`, `search`) store results in Redis for one hour (including responses with `include_serialized=true`; cache keys differ per argument set).
+When `guillotina.contrib.redis` is enabled, cacheable tools (`resolve_path`, `list_children`, `search`) store results in Redis for one hour (including responses with `include_serialized=true`; cache keys differ per argument set, authenticated principal, container, and context).
 
 Subscribers invalidate the cache on `IObjectAddedEvent`, `IObjectModifiedEvent`, and `IBeforeObjectRemovedEvent` so listings and search results stay consistent after content changes.
 
@@ -198,6 +198,8 @@ Subscribers invalidate the cache on `IObjectAddedEvent`, `IObjectModifiedEvent`,
 | `guillotina.MCPView` | Reserved for view-level MCP services (granted to Manager/Owner). |
 
 Adjust role grants in your application if non-managers should use MCP.
+
+Built-in tools also enforce content permissions internally. Minimal metadata from `resolve_path`, `list_children`, and `summary` requires `guillotina.AccessContent`. Full serialized JSON via `include_serialized=true` additionally requires `guillotina.ViewContent` on the serialized resource, matching Guillotina's default `GET` view.
 
 ## Adding tools for your project
 

--- a/guillotina/contrib/mcp/backend.py
+++ b/guillotina/contrib/mcp/backend.py
@@ -9,6 +9,7 @@ from guillotina import app_settings
 from guillotina.contrib.mcp import resources as mcp_resources
 from guillotina.contrib.mcp import tools
 from guillotina.contrib.redis import get_driver
+from guillotina.utils import get_authenticated_user, get_content_path, get_current_container
 
 
 ToolHandler = Callable[[Any, Any, Dict[str, Any]], Awaitable[Dict[str, Any]]]
@@ -199,8 +200,18 @@ class MCPToolRegistry:
         resource = self._resources[clean_name]
         return await resource.handler(request)
 
-    def _cache_key(self, tool_name: str, arguments: Dict[str, Any]) -> str:
-        payload = json.dumps(arguments, sort_keys=True, separators=(",", ":"), default=str)
+    def _cache_key(self, tool_name: str, context: Any, arguments: Dict[str, Any]) -> str:
+        principal = get_authenticated_user()
+        container = get_current_container()
+        payload = {
+            "arguments": arguments,
+            "container_id": getattr(container, "id", None),
+            "container_uid": getattr(container, "__uuid__", None),
+            "context_path": get_content_path(context),
+            "context_uid": getattr(context, "__uuid__", None),
+            "principal_id": getattr(principal, "id", None),
+        }
+        payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         return f"{self._key_cache_redis_prefix}:{tool_name}:{digest[:16]}"
 
@@ -230,7 +241,7 @@ class MCPToolRegistry:
             raise ValueError("Tool arguments must be an object")
 
         tool = self._tools[clean_name]
-        cache_key = self._cache_key(clean_name, clean_arguments)
+        cache_key = self._cache_key(clean_name, context, clean_arguments)
         if tool.cacheable and self._cache_disabled is False:
             result = await self._driver_redis.get(cache_key)
             if result is not None:

--- a/guillotina/contrib/mcp/backend.py
+++ b/guillotina/contrib/mcp/backend.py
@@ -211,8 +211,8 @@ class MCPToolRegistry:
             "context_uid": getattr(context, "__uuid__", None),
             "principal_id": getattr(principal, "id", None),
         }
-        payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+        digest = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
         return f"{self._key_cache_redis_prefix}:{tool_name}:{digest[:16]}"
 
     def _serialize_cache_value(self, value: Dict[str, Any]) -> str:

--- a/guillotina/contrib/mcp/resources.py
+++ b/guillotina/contrib/mcp/resources.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from guillotina import __version__, app_settings
 from guillotina.component import query_utility
+from guillotina.contrib.mcp.security import require_access_content, require_permission
 from guillotina.interfaces.catalog import ICatalogUtility
 from guillotina.transactions import get_transaction
 from guillotina.utils import get_content_path, get_current_container, navigate_to
@@ -36,6 +37,9 @@ async def mcp_health_resource(request) -> Dict[str, Any]:
 
 
 async def mcp_config_resource(request) -> Dict[str, Any]:
+    container = get_current_container()
+    if container is not None:
+        require_permission("guillotina.ReadConfiguration", container)
     mcp_settings = app_settings.get("mcp", {})
     return {
         "mcp": {
@@ -54,6 +58,7 @@ async def mcp_users_resource(request) -> Dict[str, Any]:
     container = get_current_container()
     if not container:
         return {"error": "No container available"}
+    require_permission("guillotina.ManageUsers", container)
 
     try:
         users_folder = await navigate_to(container, "users")
@@ -132,6 +137,7 @@ async def mcp_summary_resource(request) -> Dict[str, Any]:
             resource = container
         else:
             resource = await navigate_to(container, path)
+        require_access_content(resource)
 
         summary = {
             "path": get_content_path(resource),

--- a/guillotina/contrib/mcp/security.py
+++ b/guillotina/contrib/mcp/security.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from guillotina.response import HTTPUnauthorized
+from guillotina.utils import get_roles_principal, get_security_policy
+
+
+def has_permission(permission: str, context: Any) -> bool:
+    return bool(get_security_policy().check_permission(permission, context))
+
+
+def require_permission(permission: str, context: Any) -> None:
+    if not has_permission(permission, context):
+        raise HTTPUnauthorized(content={"reason": f"Missing permission: {permission}"})
+
+
+def require_access_content(context: Any) -> None:
+    require_permission("guillotina.AccessContent", context)
+
+
+def require_view_content(context: Any) -> None:
+    require_permission("guillotina.ViewContent", context)
+
+
+def has_manager_role(context: Any) -> bool:
+    return "guillotina.Manager" in get_roles_principal(context)

--- a/guillotina/contrib/mcp/security.py
+++ b/guillotina/contrib/mcp/security.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from guillotina.response import HTTPUnauthorized
-from guillotina.utils import get_roles_principal, get_security_policy
+from guillotina.utils import get_security_policy
 
 
 def has_permission(permission: str, context: Any) -> bool:
@@ -19,7 +19,3 @@ def require_access_content(context: Any) -> None:
 
 def require_view_content(context: Any) -> None:
     require_permission("guillotina.ViewContent", context)
-
-
-def has_manager_role(context: Any) -> bool:
-    return "guillotina.Manager" in get_roles_principal(context)

--- a/guillotina/contrib/mcp/services.py
+++ b/guillotina/contrib/mcp/services.py
@@ -2,6 +2,7 @@ from guillotina import configure
 from guillotina.api.service import Service
 from guillotina.component import query_utility
 from guillotina.contrib.mcp.interfaces import IMCPToolRegistry
+from guillotina.contrib.mcp.security import require_access_content
 from guillotina.interfaces import IResource
 from guillotina.response import HTTPNotFound, HTTPServiceUnavailable, Response
 
@@ -10,6 +11,8 @@ def _get_registry():
     registry = query_utility(IMCPToolRegistry)
     if registry is None:
         raise HTTPServiceUnavailable(content={"reason": "MCP registry utility is not available"})
+    if not registry.is_enabled():
+        raise HTTPServiceUnavailable(content={"reason": "MCP integration is disabled"})
     return registry
 
 
@@ -23,6 +26,7 @@ def _get_registry():
 )
 class MCPActionPostService(Service):
     async def __call__(self):
+        require_access_content(self.context)
         action = self.request.matchdict.get("action", "")
         if action == "protocol":
             return await self._handle_protocol()

--- a/guillotina/contrib/mcp/subscribers.py
+++ b/guillotina/contrib/mcp/subscribers.py
@@ -5,12 +5,14 @@ from guillotina.interfaces import (
     IBeforeObjectRemovedEvent,
     IObjectAddedEvent,
     IObjectModifiedEvent,
+    IObjectPermissionsModifiedEvent,
     IResource,
 )
 
 
 @configure.subscriber(for_=(IResource, IObjectAddedEvent))
 @configure.subscriber(for_=(IResource, IObjectModifiedEvent))
+@configure.subscriber(for_=(IResource, IObjectPermissionsModifiedEvent))
 @configure.subscriber(for_=(IResource, IBeforeObjectRemovedEvent))
 async def invalidate_mcp_cache_on_content_change(obj, event):
     registry = query_utility(IMCPToolRegistry)

--- a/guillotina/contrib/mcp/tools.py
+++ b/guillotina/contrib/mcp/tools.py
@@ -4,7 +4,6 @@ from typing import Any, Awaitable, Callable, Dict, List, Tuple
 from guillotina.catalog.catalog import DefaultSearchUtility
 from guillotina.component import query_multi_adapter, query_utility
 from guillotina.contrib.mcp.security import (
-    has_manager_role,
     has_permission,
     require_access_content,
     require_permission,
@@ -272,8 +271,7 @@ async def _list_children_from_async_items(
 
 
 async def search_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
-    if not has_permission("guillotina.SearchContent", context) and not has_manager_role(context):
-        require_permission("guillotina.SearchContent", context)
+    require_permission("guillotina.SearchContent", context)
     catalog = _get_catalog_utility()
     if catalog is None:
         raise ValueError("Catalog utility is not available")

--- a/guillotina/contrib/mcp/tools.py
+++ b/guillotina/contrib/mcp/tools.py
@@ -3,6 +3,13 @@ from typing import Any, Awaitable, Callable, Dict, List, Tuple
 
 from guillotina.catalog.catalog import DefaultSearchUtility
 from guillotina.component import query_multi_adapter, query_utility
+from guillotina.contrib.mcp.security import (
+    has_manager_role,
+    has_permission,
+    require_access_content,
+    require_permission,
+    require_view_content,
+)
 from guillotina.interfaces import IResourceSerializeToJson, IResourceSerializeToJsonSummary
 from guillotina.interfaces.catalog import ICatalogUtility
 from guillotina.utils import get_content_path, get_current_container, navigate_to
@@ -94,6 +101,8 @@ def _resource_summary(resource: Any, path_hint: str = "") -> Dict[str, Any]:
 
 
 async def _serialize_resource(resource: Any, request: Any) -> Dict[str, Any]:
+    require_access_content(resource)
+    require_view_content(resource)
     serializer = query_multi_adapter((resource, request), IResourceSerializeToJson)
     if serializer is None:
         serializer = query_multi_adapter((resource, request), IResourceSerializeToJsonSummary)
@@ -121,6 +130,7 @@ async def _resolve_target(context: Any, raw_path: Any) -> Tuple[Any, str]:
 
 async def resolve_path_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
     target, resolved_path = await _resolve_target(context, arguments.get("path", "/"))
+    require_access_content(target)
     result = {
         "path": resolved_path,
         "resource": _resource_summary(target, get_content_path(target)),
@@ -134,6 +144,7 @@ async def list_children_tool(
     context: Any, request: Any, arguments: Dict[str, Any], default_limit: int = 50
 ) -> Dict[str, Any]:
     target, resolved_path = await _resolve_target(context, arguments.get("path", "/"))
+    require_access_content(target)
     if not hasattr(target, "async_items"):
         raise ValueError("Target path does not point to a folder-like resource")
 
@@ -238,6 +249,8 @@ async def _list_children_from_async_items(
     end_index = page * limit
 
     async for _, child in target.async_items():
+        if not has_permission("guillotina.AccessContent", child):
+            continue
         if count >= start_index and count < end_index:
             item_summary = _resource_summary(child, get_content_path(child))
             if include_serialized:
@@ -259,6 +272,8 @@ async def _list_children_from_async_items(
 
 
 async def search_tool(context: Any, request: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    if not has_permission("guillotina.SearchContent", context) and not has_manager_role(context):
+        require_permission("guillotina.SearchContent", context)
     catalog = _get_catalog_utility()
     if catalog is None:
         raise ValueError("Catalog utility is not available")

--- a/guillotina/tests/mcp/test_mcp.py
+++ b/guillotina/tests/mcp/test_mcp.py
@@ -439,6 +439,22 @@ async def test_search_tool_uses_catalog_security_filter(container_requester):
         assert status == 200
         _, status = await requester(
             "POST",
+            "/db/guillotina/@sharing",
+            data=json.dumps(
+                {
+                    "prinperm": [
+                        {
+                            "principal": "mcp-manager",
+                            "permission": "guillotina.SearchContent",
+                            "setting": "Allow",
+                        }
+                    ]
+                }
+            ),
+        )
+        assert status == 200
+        _, status = await requester(
+            "POST",
             "/db/guillotina/secret-item/@sharing",
             data=json.dumps({"perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}]}),
         )
@@ -452,6 +468,7 @@ async def test_search_tool_uses_catalog_security_filter(container_requester):
             utils.login(user=manager)
             policy = get_security_policy(manager)
             assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.SearchContent", container)
             assert policy.check_permission("guillotina.AccessContent", visible)
             assert not policy.check_permission("guillotina.AccessContent", secret)
 
@@ -644,7 +661,7 @@ async def test_search_tool_requires_search_content_permission(container_requeste
 
         async with requester.transaction():
             container = await utils.get_container(requester=requester)
-            executor = GuillotinaUser("mcp-executor", permissions={"guillotina.MCPExecute": Allow})
+            executor = GuillotinaUser("mcp-executor", roles={"guillotina.Manager": Allow})
             utils.login(user=executor)
             policy = get_security_policy(executor)
             assert policy.check_permission("guillotina.MCPExecute", container)

--- a/guillotina/tests/mcp/test_mcp.py
+++ b/guillotina/tests/mcp/test_mcp.py
@@ -345,60 +345,6 @@ async def test_list_children_tool_filters_inaccessible_children(container_reques
 
 
 @pytest.mark.app_settings(MCP_SETTINGS)
-async def test_list_children_tool_serialized_requires_view_content(container_requester):
-    async with container_requester as requester:
-        _, status = await requester(
-            "POST",
-            "/db/guillotina",
-            data=json.dumps({"@type": "Folder", "id": "viewless-folder"}),
-        )
-        assert status == 201
-        _, status = await requester(
-            "POST",
-            "/db/guillotina/viewless-folder",
-            data=json.dumps({"@type": "Item", "id": "viewless-child"}),
-        )
-        assert status == 201
-
-        async with requester.transaction():
-            container = await utils.get_container(requester=requester)
-            folder = await container.async_get("viewless-folder")
-            child = await folder.async_get("viewless-child")
-            executor = GuillotinaUser(
-                "mcp-viewless",
-                permissions={
-                    "guillotina.MCPExecute": Allow,
-                    "guillotina.AccessContent": Allow,
-                },
-            )
-            utils.login(user=executor)
-            policy = get_security_policy(executor)
-            assert policy.check_permission("guillotina.MCPExecute", container)
-            assert policy.check_permission("guillotina.AccessContent", folder)
-            assert policy.check_permission("guillotina.AccessContent", child)
-            assert not policy.check_permission("guillotina.ViewContent", child)
-
-            registry = query_utility(IMCPToolRegistry)
-            request = utils.get_mocked_request(db=requester.db)
-            result = await registry.invoke(
-                "list_children",
-                container,
-                request,
-                {"path": "/viewless-folder"},
-            )
-            assert {item["id"] for item in result["items"]} == {"viewless-child"}
-            assert "serialized" not in result["items"][0]
-
-            with pytest.raises(HTTPUnauthorized):
-                await registry.invoke(
-                    "list_children",
-                    container,
-                    request,
-                    {"path": "/viewless-folder", "include_serialized": True},
-                )
-
-
-@pytest.mark.app_settings(MCP_SETTINGS)
 async def test_tool_cache_isolated_by_effective_security(container_requester):
     async with container_requester as requester:
         _, status = await requester(

--- a/guillotina/tests/mcp/test_mcp.py
+++ b/guillotina/tests/mcp/test_mcp.py
@@ -1,13 +1,25 @@
 import asyncio
+import base64
 import json
+import os
 
 import pytest
 
+from guillotina.auth.users import GuillotinaUser
+from guillotina.component import query_utility
 from guillotina.contrib.mcp import resources as mcp_resources
-from guillotina.utils import resolve_dotted_name
+from guillotina.contrib.mcp import tools as mcp_tools
+from guillotina.contrib.mcp.interfaces import IMCPToolRegistry
+from guillotina.interfaces import Allow
+from guillotina.interfaces.catalog import ICatalogUtility
+from guillotina.response import HTTPUnauthorized
+from guillotina.tests import utils
+from guillotina.utils import get_security_policy, resolve_dotted_name
 
 
 pytestmark = pytest.mark.asyncio
+
+NOT_POSTGRES = os.environ.get("DATABASE", "DUMMY") in ("cockroachdb", "DUMMY")
 
 MCP_SETTINGS = {
     "applications": ["guillotina", "guillotina.contrib.mcp"],
@@ -21,10 +33,55 @@ MCP_SETTINGS_REDIS = {
     ],
 }
 
+MCP_SETTINGS_DISABLED = {
+    "applications": ["guillotina", "guillotina.contrib.mcp"],
+    "mcp": {"enabled": False},
+}
+
+MCP_SETTINGS_DBUSERS = {
+    "applications": ["guillotina", "guillotina.contrib.dbusers", "guillotina.contrib.mcp"],
+    "auth_user_identifiers": ["guillotina.contrib.dbusers.users.DBUserIdentifier"],
+}
+
+MCP_SETTINGS_PG_CATALOG = {
+    "applications": ["guillotina", "guillotina.contrib.mcp", "guillotina.contrib.catalog.pg"],
+    "load_utilities": {
+        "catalog": {
+            "provides": "guillotina.interfaces.ICatalogUtility",
+            "factory": "guillotina.contrib.catalog.pg.utility.PGSearchUtility",
+        }
+    },
+}
+
 PROTOCOL_HEADERS = {
     "Content-Type": "application/json",
     "Accept": "application/json, text/event-stream",
 }
+
+
+class _MemoryCacheDriver:
+    def __init__(self):
+        self._data = {}
+
+    async def get(self, key):
+        return self._data.get(key)
+
+    async def set(self, key, data, expire=None):
+        self._data[key] = data
+
+
+class _EmptyCatalog:
+    async def search(self, context, query):
+        return {"items": [], "items_total": 0}
+
+
+class _RequestWithQuery:
+    def __init__(self, request, query):
+        self._request = request
+        self.query = query
+
+    def __getattr__(self, name):
+        return getattr(self._request, name)
 
 
 def _skip_if_protocol_unavailable(response, status):
@@ -130,6 +187,661 @@ async def test_protocol_tools_call_unknown_tool_returns_error(container_requeste
         assert status == 200
         # Unknown tool: SDK returns a tool result with isError=True (not a JSON-RPC error)
         assert response["result"]["isError"] is True
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_resolve_path_tool_respects_access_content(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Item", "id": "secret-item"}),
+        )
+        assert status == 201
+
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/secret-item/@sharing",
+            data=json.dumps(
+                {
+                    "perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}],
+                    "roleperm": [
+                        {
+                            "permission": "guillotina.AccessContent",
+                            "role": "guillotina.Owner",
+                            "setting": "Allow",
+                        }
+                    ],
+                }
+            ),
+        )
+        assert status == 200
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            secret = await container.async_get("secret-item")
+            manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+            utils.login(user=manager)
+            policy = get_security_policy(manager)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert not policy.check_permission("guillotina.AccessContent", secret)
+
+            registry = query_utility(IMCPToolRegistry)
+            with pytest.raises(HTTPUnauthorized):
+                await registry.invoke(
+                    "resolve_path",
+                    container,
+                    utils.get_mocked_request(db=requester.db),
+                    {"path": "/secret-item"},
+                )
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_resolve_path_tool_serialized_requires_view_content(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Item", "id": "viewless-item"}),
+        )
+        assert status == 201
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            viewless = await container.async_get("viewless-item")
+            executor = GuillotinaUser(
+                "mcp-viewless",
+                permissions={
+                    "guillotina.MCPExecute": Allow,
+                    "guillotina.AccessContent": Allow,
+                },
+            )
+            utils.login(user=executor)
+            policy = get_security_policy(executor)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.AccessContent", viewless)
+            assert not policy.check_permission("guillotina.ViewContent", viewless)
+
+            registry = query_utility(IMCPToolRegistry)
+            request = utils.get_mocked_request(db=requester.db)
+            result = await registry.invoke(
+                "resolve_path",
+                container,
+                request,
+                {"path": "/viewless-item"},
+            )
+            assert result["resource"]["id"] == "viewless-item"
+            assert "serialized" not in result
+
+            with pytest.raises(HTTPUnauthorized):
+                await registry.invoke(
+                    "resolve_path",
+                    container,
+                    request,
+                    {"path": "/viewless-item", "include_serialized": True},
+                )
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_list_children_tool_filters_inaccessible_children(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Folder", "id": "mcp-folder"}),
+        )
+        assert status == 201
+        for item_id in ("visible-item", "secret-item"):
+            _, status = await requester(
+                "POST",
+                "/db/guillotina/mcp-folder",
+                data=json.dumps({"@type": "Item", "id": item_id}),
+            )
+            assert status == 201
+
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/mcp-folder/@sharing",
+            data=json.dumps(
+                {
+                    "prinperm": [
+                        {
+                            "principal": "mcp-manager",
+                            "permission": "guillotina.AccessContent",
+                            "setting": "Allow",
+                        }
+                    ]
+                }
+            ),
+        )
+        assert status == 200
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/mcp-folder/secret-item/@sharing",
+            data=json.dumps({"perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}]}),
+        )
+        assert status == 200
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            folder = await container.async_get("mcp-folder")
+            secret = await folder.async_get("secret-item")
+            manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+            utils.login(user=manager)
+            policy = get_security_policy(manager)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.AccessContent", folder)
+            assert not policy.check_permission("guillotina.AccessContent", secret)
+
+            registry = query_utility(IMCPToolRegistry)
+            result = await registry.invoke(
+                "list_children",
+                container,
+                utils.get_mocked_request(db=requester.db),
+                {"path": "/mcp-folder"},
+            )
+
+        assert {item["id"] for item in result["items"]} == {"visible-item"}
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_list_children_tool_serialized_requires_view_content(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Folder", "id": "viewless-folder"}),
+        )
+        assert status == 201
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/viewless-folder",
+            data=json.dumps({"@type": "Item", "id": "viewless-child"}),
+        )
+        assert status == 201
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            folder = await container.async_get("viewless-folder")
+            child = await folder.async_get("viewless-child")
+            executor = GuillotinaUser(
+                "mcp-viewless",
+                permissions={
+                    "guillotina.MCPExecute": Allow,
+                    "guillotina.AccessContent": Allow,
+                },
+            )
+            utils.login(user=executor)
+            policy = get_security_policy(executor)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.AccessContent", folder)
+            assert policy.check_permission("guillotina.AccessContent", child)
+            assert not policy.check_permission("guillotina.ViewContent", child)
+
+            registry = query_utility(IMCPToolRegistry)
+            request = utils.get_mocked_request(db=requester.db)
+            result = await registry.invoke(
+                "list_children",
+                container,
+                request,
+                {"path": "/viewless-folder"},
+            )
+            assert {item["id"] for item in result["items"]} == {"viewless-child"}
+            assert "serialized" not in result["items"][0]
+
+            with pytest.raises(HTTPUnauthorized):
+                await registry.invoke(
+                    "list_children",
+                    container,
+                    request,
+                    {"path": "/viewless-folder", "include_serialized": True},
+                )
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_tool_cache_isolated_by_effective_security(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Item", "id": "cached-secret-item"}),
+        )
+        assert status == 201
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/cached-secret-item/@sharing",
+            data=json.dumps(
+                {
+                    "perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}],
+                    "roleperm": [
+                        {
+                            "permission": "guillotina.AccessContent",
+                            "role": "guillotina.Owner",
+                            "setting": "Allow",
+                        }
+                    ],
+                }
+            ),
+        )
+        assert status == 200
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            secret = await container.async_get("cached-secret-item")
+            registry = query_utility(IMCPToolRegistry)
+            cache_disabled = registry._cache_disabled
+            driver_redis = registry._driver_redis
+            registry._cache_disabled = False
+            registry._driver_redis = _MemoryCacheDriver()
+            request = utils.get_mocked_request(db=requester.db)
+
+            try:
+                utils.login()
+                root_result = await registry.invoke(
+                    "resolve_path",
+                    container,
+                    request,
+                    {"path": "/cached-secret-item"},
+                )
+                assert root_result["resource"]["id"] == "cached-secret-item"
+
+                manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+                utils.login(user=manager)
+                policy = get_security_policy(manager)
+                assert policy.check_permission("guillotina.MCPExecute", container)
+                assert not policy.check_permission("guillotina.AccessContent", secret)
+
+                with pytest.raises(HTTPUnauthorized):
+                    await registry.invoke(
+                        "resolve_path",
+                        container,
+                        request,
+                        {"path": "/cached-secret-item"},
+                    )
+            finally:
+                registry._cache_disabled = cache_disabled
+                registry._driver_redis = driver_redis
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_PG_CATALOG)
+@pytest.mark.skipif(NOT_POSTGRES, reason="Only PG")
+async def test_search_tool_uses_catalog_security_filter(container_requester):
+    async with container_requester as requester:
+        for item_id in ("visible-item", "secret-item"):
+            _, status = await requester(
+                "POST",
+                "/db/guillotina",
+                data=json.dumps({"@type": "Item", "id": item_id}),
+            )
+            assert status == 201
+
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/visible-item/@sharing",
+            data=json.dumps(
+                {
+                    "prinperm": [
+                        {
+                            "principal": "mcp-manager",
+                            "permission": "guillotina.AccessContent",
+                            "setting": "Allow",
+                        }
+                    ]
+                }
+            ),
+        )
+        assert status == 200
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/secret-item/@sharing",
+            data=json.dumps({"perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}]}),
+        )
+        assert status == 200
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            visible = await container.async_get("visible-item")
+            secret = await container.async_get("secret-item")
+            manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+            utils.login(user=manager)
+            policy = get_security_policy(manager)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.AccessContent", visible)
+            assert not policy.check_permission("guillotina.AccessContent", secret)
+
+            registry = query_utility(IMCPToolRegistry)
+            result = await registry.invoke(
+                "search",
+                container,
+                utils.get_mocked_request(db=requester.db),
+                {"query": {"type_name": "Item", "_metadata": "id,type_name,title,path"}},
+            )
+
+        assert {item["id"] for item in result["result"]["items"]} == {"visible-item"}
+        assert result["result"]["items_total"] == 1
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_PG_CATALOG)
+@pytest.mark.skipif(NOT_POSTGRES, reason="Only PG")
+async def test_list_children_tool_uses_catalog_security_filter(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Folder", "id": "catalog-folder"}),
+        )
+        assert status == 201
+        for item_id in ("visible-child", "secret-child"):
+            _, status = await requester(
+                "POST",
+                "/db/guillotina/catalog-folder",
+                data=json.dumps({"@type": "Item", "id": item_id}),
+            )
+            assert status == 201
+
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/catalog-folder/@sharing",
+            data=json.dumps(
+                {
+                    "prinperm": [
+                        {
+                            "principal": "mcp-manager",
+                            "permission": "guillotina.AccessContent",
+                            "setting": "Allow",
+                        },
+                        {
+                            "principal": "mcp-manager",
+                            "permission": "guillotina.ViewContent",
+                            "setting": "Allow",
+                        },
+                    ]
+                }
+            ),
+        )
+        assert status == 200
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/catalog-folder/secret-child/@sharing",
+            data=json.dumps({"perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}]}),
+        )
+        assert status == 200
+        await asyncio.sleep(0.5)
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            folder = await container.async_get("catalog-folder")
+            secret = await folder.async_get("secret-child")
+            manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+            utils.login(user=manager)
+            policy = get_security_policy(manager)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert policy.check_permission("guillotina.AccessContent", folder)
+            assert policy.check_permission("guillotina.ViewContent", folder)
+            assert not policy.check_permission("guillotina.AccessContent", secret)
+
+            registry = query_utility(IMCPToolRegistry)
+            result = await registry.invoke(
+                "list_children",
+                container,
+                utils.get_mocked_request(db=requester.db),
+                {"path": "/catalog-folder", "include_serialized": True},
+            )
+
+        assert {item["id"] for item in result["items"]} == {"visible-child"}
+        item = result["items"][0]
+        assert item["serialized"]["@name"] == "visible-child"
+        assert item["serialized"]["@type"] == "Item"
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_summary_resource_respects_access_content(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Item", "id": "secret-summary-item"}),
+        )
+        assert status == 201
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/secret-summary-item/@sharing",
+            data=json.dumps(
+                {
+                    "perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}],
+                    "roleperm": [
+                        {
+                            "permission": "guillotina.AccessContent",
+                            "role": "guillotina.Owner",
+                            "setting": "Allow",
+                        }
+                    ],
+                }
+            ),
+        )
+        assert status == 200
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            secret = await container.async_get("secret-summary-item")
+            manager = GuillotinaUser("mcp-manager", roles={"guillotina.Manager": Allow})
+            utils.login(user=manager)
+            policy = get_security_policy(manager)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert not policy.check_permission("guillotina.AccessContent", secret)
+
+            registry = query_utility(IMCPToolRegistry)
+            request = _RequestWithQuery(
+                utils.get_mocked_request(db=requester.db), {"path": "/secret-summary-item"}
+            )
+            with pytest.raises(HTTPUnauthorized):
+                await registry.read_resource("summary", container, request)
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_DBUSERS)
+async def test_users_resource_requires_manage_users(dbusers_requester):
+    async with dbusers_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/users",
+            data=json.dumps(
+                {
+                    "@type": "User",
+                    "id": "listed-user",
+                    "username": "listed-user",
+                    "email": "listed@example.com",
+                    "password": "password",
+                }
+            ),
+        )
+        assert status == 201
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            executor = GuillotinaUser("mcp-executor", permissions={"guillotina.MCPExecute": Allow})
+            utils.login(user=executor)
+            policy = get_security_policy(executor)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert not policy.check_permission("guillotina.ManageUsers", container)
+
+            registry = query_utility(IMCPToolRegistry)
+            with pytest.raises(HTTPUnauthorized):
+                await registry.read_resource("users", container, utils.get_mocked_request(db=requester.db))
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_config_resource_requires_read_configuration(container_requester):
+    async with container_requester as requester:
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            executor = GuillotinaUser("mcp-executor", permissions={"guillotina.MCPExecute": Allow})
+            utils.login(user=executor)
+            policy = get_security_policy(executor)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert not policy.check_permission("guillotina.ReadConfiguration", container)
+
+            registry = query_utility(IMCPToolRegistry)
+            with pytest.raises(HTTPUnauthorized):
+                await registry.read_resource("config", container, utils.get_mocked_request(db=requester.db))
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_search_tool_requires_search_content_permission(container_requester, monkeypatch):
+    async with container_requester as requester:
+
+        def query_catalog_utility(interface, default=None):
+            if interface is ICatalogUtility:
+                return _EmptyCatalog()
+            return default
+
+        monkeypatch.setattr(mcp_tools, "query_utility", query_catalog_utility)
+
+        async with requester.transaction():
+            container = await utils.get_container(requester=requester)
+            executor = GuillotinaUser("mcp-executor", permissions={"guillotina.MCPExecute": Allow})
+            utils.login(user=executor)
+            policy = get_security_policy(executor)
+            assert policy.check_permission("guillotina.MCPExecute", container)
+            assert not policy.check_permission("guillotina.SearchContent", container)
+
+            registry = query_utility(IMCPToolRegistry)
+            with pytest.raises(HTTPUnauthorized):
+                await registry.invoke(
+                    "search",
+                    container,
+                    utils.get_mocked_request(db=requester.db),
+                    {"query": {"type_name": "Item"}},
+                )
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_DISABLED)
+async def test_mcp_disabled_rejects_protocol_requests(container_requester):
+    async with container_requester as requester:
+        response, status = await requester(
+            "POST",
+            "/db/guillotina/@mcp/protocol",
+            data=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "1.0"},
+                    },
+                }
+            ),
+            headers=PROTOCOL_HEADERS,
+        )
+        assert status in (404, 503)
+        if status == 503 and isinstance(response, dict):
+            reason = str(response.get("reason") or response.get("message") or "")
+            assert "disabled" in reason.lower()
+
+
+@pytest.mark.app_settings(MCP_SETTINGS)
+async def test_tool_cache_isolated_by_container_context(container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db",
+            data=json.dumps(
+                {
+                    "@type": "Container",
+                    "title": "Other Container",
+                    "id": "mcp-other",
+                    "description": "Other container",
+                }
+            ),
+        )
+        assert status == 200
+
+        try:
+            async with requester.transaction():
+                registry = query_utility(IMCPToolRegistry)
+                cache_disabled = registry._cache_disabled
+                driver_redis = registry._driver_redis
+                registry._cache_disabled = False
+                registry._driver_redis = _MemoryCacheDriver()
+                request = utils.get_mocked_request(db=requester.db)
+
+                try:
+                    utils.login()
+                    first_container = await utils.get_container(
+                        requester=requester, container_id="guillotina"
+                    )
+                    first_result = await registry.invoke(
+                        "resolve_path", first_container, request, {"path": "/"}
+                    )
+                    assert first_result["resource"]["id"] == "guillotina"
+
+                    second_container = await utils.get_container(
+                        requester=requester, container_id="mcp-other"
+                    )
+                    second_result = await registry.invoke(
+                        "resolve_path", second_container, request, {"path": "/"}
+                    )
+                    assert second_result["resource"]["id"] == "mcp-other"
+                finally:
+                    registry._cache_disabled = cache_disabled
+                    registry._driver_redis = driver_redis
+        finally:
+            await requester("DELETE", "/db/mcp-other")
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_DBUSERS)
+async def test_protocol_requires_access_content_on_invocation_context(dbusers_requester):
+    async with dbusers_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/users",
+            data=json.dumps(
+                {
+                    "@type": "User",
+                    "id": "mcp-manager",
+                    "username": "mcp-manager",
+                    "email": "manager@example.com",
+                    "password": "password",
+                    "user_roles": ["guillotina.Manager"],
+                }
+            ),
+        )
+        assert status == 201
+        _, status = await requester(
+            "POST",
+            "/db/guillotina",
+            data=json.dumps({"@type": "Item", "id": "private-context"}),
+        )
+        assert status == 201
+        _, status = await requester(
+            "POST",
+            "/db/guillotina/private-context/@sharing",
+            data=json.dumps({"perminhe": [{"permission": "guillotina.AccessContent", "setting": "Deny"}]}),
+        )
+        assert status == 200
+
+        response, status = await requester(
+            "POST",
+            "/db/guillotina/private-context/@mcp/protocol",
+            data=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "1.0"},
+                    },
+                }
+            ),
+            headers=PROTOCOL_HEADERS,
+            token=base64.b64encode(b"mcp-manager:password").decode("ascii"),
+            auth_type="Basic",
+        )
+        _skip_if_protocol_unavailable(response, status)
+        assert status == 401
 
 
 @pytest.mark.app_settings(MCP_SETTINGS)
@@ -264,6 +976,57 @@ async def test_invoke_resolve_path_tool(container_requester):
         content = json.loads(response["result"]["content"][0]["text"])
         assert content["resource"]["@type"] == "Item"
         assert content["path"] == "/foo_item"
+
+
+@pytest.mark.app_settings(MCP_SETTINGS_REDIS)
+async def test_cache_redis_isolated_by_container_context(redis_container, container_requester):
+    async with container_requester as requester:
+        _, status = await requester(
+            "POST",
+            "/db",
+            data=json.dumps(
+                {
+                    "@type": "Container",
+                    "title": "Other Container",
+                    "id": "mcp-other",
+                    "description": "Other container",
+                }
+            ),
+        )
+        assert status == 200
+
+        driver = await resolve_dotted_name("guillotina.contrib.redis").get_driver()
+        assert driver.initialized
+        keys = await driver.keys_startswith("mcp_tool_cache:v1")
+        await driver.delete_all(keys)
+
+        try:
+            async with requester.transaction():
+                utils.login()
+                registry = query_utility(IMCPToolRegistry)
+                assert registry._cache_disabled is False
+
+                first_container = await utils.get_container(requester=requester, container_id="guillotina")
+                first_result = await registry.invoke(
+                    "resolve_path",
+                    first_container,
+                    utils.get_mocked_request(db=requester.db),
+                    {"path": "/"},
+                )
+                assert first_result["resource"]["id"] == "guillotina"
+
+                second_container = await utils.get_container(requester=requester, container_id="mcp-other")
+                second_result = await registry.invoke(
+                    "resolve_path",
+                    second_container,
+                    utils.get_mocked_request(db=requester.db),
+                    {"path": "/"},
+                )
+                assert second_result["resource"]["id"] == "mcp-other"
+        finally:
+            keys = await driver.keys_startswith("mcp_tool_cache:v1")
+            await driver.delete_all(keys)
+            await requester("DELETE", "/db/mcp-other")
 
 
 @pytest.mark.app_settings(MCP_SETTINGS_REDIS)


### PR DESCRIPTION
## Summary

This PR tightens the security model for `guillotina.contrib.mcp` so MCP tools and resources follow Guillotina's existing content permission semantics.

## Problem

The MCP endpoint itself required `guillotina.MCPExecute`, but some tool/resource implementations did not consistently enforce the same internal permissions that Guillotina applies when resolving, listing, searching, and serializing content.

The most important issue was that MCP could return full serialized resource JSON through `include_serialized=true` after only checking `guillotina.AccessContent`. A normal Guillotina `GET` first requires `AccessContent` for traversal and then requires `guillotina.ViewContent` on the default GET view. That meant MCP full serialization was not fully aligned with the REST API security model.

There were also cache-safety concerns: cached MCP tool responses needed to be scoped by the authenticated principal and execution context so data returned for one user/container/context could not be reused for another.

## Changes

- Add MCP security helpers for permission checks.
- Require `guillotina.AccessContent` when resolving paths and listing children.
- Require `guillotina.ViewContent` for full MCP serialization via `include_serialized=true`, matching normal `GET` behavior.
- Keep minimal summaries based on `AccessContent` only.
- Filter `list_children` fallback results from `async_items()` by `AccessContent`.
- Keep catalog-backed search/listing delegated to the catalog security filtering.
- Require specific permissions for sensitive resources:
  - `ReadConfiguration` for MCP config.
  - `ManageUsers` for MCP users.
  - `AccessContent` for MCP summaries.
- Require `AccessContent` on the MCP invocation context.
- Disable the protocol endpoint when `mcp.enabled=false`.
- Scope MCP cache keys by authenticated principal, container, context, and arguments.
- Invalidate MCP cache on permission changes.
- Update MCP documentation to describe the permission model.

## Validation

- `pyenv exec python -m pytest guillotina/tests/mcp/test_mcp.py`
- `DATABASE=postgres pyenv exec python -m pytest guillotina/tests/mcp/test_mcp.py::test_search_tool_uses_catalog_security_filter guillotina/tests/mcp/test_mcp.py::test_list_children_tool_uses_catalog_security_filter`
- `pyenv exec python -m black --check guillotina/contrib/mcp guillotina/tests/mcp/test_mcp.py`
- `pyenv exec python -m isort --check-only guillotina/contrib/mcp/*.py guillotina/tests/mcp/test_mcp.py`
- `pyenv exec python -m flake8 guillotina/contrib/mcp guillotina/tests/mcp/test_mcp.py --config=setup.cfg`

Note: the PostgreSQL-focused test command passes, but the local test run still prints existing asyncpg cleanup warnings after completion (`Task was destroyed but it is pending!`).
